### PR TITLE
Add RBAC middleware for backend

### DIFF
--- a/packages/backend/app/middleware/auth_middleware.ts
+++ b/packages/backend/app/middleware/auth_middleware.ts
@@ -1,0 +1,34 @@
+import { HttpContext } from '@adonisjs/core/http'
+import type { NextFn } from '@adonisjs/core/types/http'
+import { JwtTokenProvider } from '#auth/secondary/adapters/jwt_token_provider'
+import { Role } from '#auth/domain/role'
+
+export default class AuthMiddleware {
+  private tokenProvider = new JwtTokenProvider()
+
+  async handle({ request, response }: HttpContext, next: NextFn, role: Role) {
+    const header = request.header('authorization')
+    if (!header) {
+      response.forbidden({ error: 'Accès interdit' })
+      return
+    }
+
+    const tokenMatch = header.match(/Bearer\s+(.*)/i)
+    if (!tokenMatch) {
+      response.forbidden({ error: 'Accès interdit' })
+      return
+    }
+
+    try {
+      const payload = this.tokenProvider.verify(tokenMatch[1]) as { roles?: Role[] }
+      const roles = Array.isArray(payload.roles) ? payload.roles : []
+      if (roles.includes(role)) {
+        await next()
+        return
+      }
+    } catch (e) {
+      // ignore error and return forbidden
+    }
+    response.forbidden({ error: 'Accès interdit' })
+  }
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,8 +8,8 @@
     "start": "node bin/server.js",
     "build": "node ace build",
     "dev": "node ace serve --hmr",
-    "test": "node ace test --reporters=spec",
-    "coverage": "c8 --all -n app --reporters=lcov node ace test",
+    "test": "APP_KEY=abcdefghijklmnopabcdefghijklmnop node ace test --reporters=spec",
+    "coverage": "APP_KEY=abcdefghijklmnopabcdefghijklmnop c8 --all -n app --reporters=lcov node ace test",
     "lint": "eslint .",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit"

--- a/packages/backend/start/kernel.ts
+++ b/packages/backend/start/kernel.ts
@@ -38,4 +38,6 @@ router.use([() => import('@adonisjs/core/bodyparser_middleware')])
  * Named middleware collection must be explicitly assigned to
  * the routes or the routes group.
  */
-export const middleware = router.named({})
+export const middleware = router.named({
+  auth: () => import('#middleware/auth_middleware'),
+})

--- a/packages/backend/start/routes.ts
+++ b/packages/backend/start/routes.ts
@@ -17,6 +17,8 @@ router.get('/', async () => {
   }
 })
 
-router.get('/admin', async () => {
-  return { ok: true }
-}).use(middleware.auth(Role.ADMIN))
+router
+  .get('/admin', async () => {
+    return { ok: true }
+  })
+  .use(middleware.auth(Role.ADMIN))

--- a/packages/backend/start/routes.ts
+++ b/packages/backend/start/routes.ts
@@ -8,9 +8,15 @@
 */
 
 import router from '@adonisjs/core/services/router'
+import { Role } from '#auth/domain/role'
+import { middleware } from '#start/kernel'
 
 router.get('/', async () => {
   return {
     hello: 'world',
   }
 })
+
+router.get('/admin', async () => {
+  return { ok: true }
+}).use(middleware.auth(Role.ADMIN))

--- a/packages/backend/tests/bootstrap.ts
+++ b/packages/backend/tests/bootstrap.ts
@@ -5,6 +5,9 @@ import type { Config } from '@japa/runner/types'
 import { pluginAdonisJS } from '@japa/plugin-adonisjs'
 import testUtils from '@adonisjs/core/services/test_utils'
 
+process.env.JWT_SECRET = 'testsecret'
+process.env.JWT_EXPIRES_IN = '1h'
+
 /**
  * This file is imported by the "bin/test.ts" entrypoint file
  */

--- a/packages/backend/tests/functional/auth/auth_middleware.spec.ts
+++ b/packages/backend/tests/functional/auth/auth_middleware.spec.ts
@@ -1,0 +1,27 @@
+import { test } from '@japa/runner'
+import { JwtTokenProvider } from '#auth/secondary/adapters/jwt_token_provider'
+import { Role } from '#auth/domain/role'
+
+process.env.JWT_SECRET = 'testsecret'
+process.env.JWT_EXPIRES_IN = '1h'
+
+const tokenProvider = new JwtTokenProvider()
+
+test.group('AuthMiddleware', () => {
+  test('autorise l\'accès pour un rôle présent', async ({ client }) => {
+    const token = tokenProvider.generate({ roles: [Role.ADMIN] })
+    const response = await client.get('/admin').header('Authorization', `Bearer ${token}`).send()
+    response.assertOk()
+  })
+
+  test('renvoie 403 pour rôle manquant', async ({ client }) => {
+    const token = tokenProvider.generate({ roles: [Role.GUEST] })
+    const response = await client.get('/admin').header('Authorization', `Bearer ${token}`).send()
+    response.assertForbidden()
+  })
+
+  test('renvoie 403 pour token invalide', async ({ client }) => {
+    const response = await client.get('/admin').header('Authorization', 'Bearer bad').send()
+    response.assertForbidden()
+  })
+})

--- a/packages/backend/tests/functional/auth/auth_middleware.spec.ts
+++ b/packages/backend/tests/functional/auth/auth_middleware.spec.ts
@@ -8,7 +8,7 @@ process.env.JWT_EXPIRES_IN = '1h'
 const tokenProvider = new JwtTokenProvider()
 
 test.group('AuthMiddleware', () => {
-  test('autorise l\'accès pour un rôle présent', async ({ client }) => {
+  test("autorise l'accès pour un rôle présent", async ({ client }) => {
     const token = tokenProvider.generate({ roles: [Role.ADMIN] })
     const response = await client.get('/admin').header('Authorization', `Bearer ${token}`).send()
     response.assertOk()


### PR DESCRIPTION
## Summary
- create `AuthMiddleware` to enforce role-based access using JWT
- register middleware and add a protected `/admin` route
- add integration tests for the middleware
- ensure tests run with required env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850611719088329b7022b800d402239