### PR TITLE
Add Match domain entity

### DIFF
--- a/packages/backend/app/modules/match/domain/match.ts
+++ b/packages/backend/app/modules/match/domain/match.ts
@@ -1,0 +1,70 @@
+import { Entity } from '#shared/domaine/entity'
+import { Identifier } from '#shared/domaine/identifier'
+
+interface Properties {
+  id: Identifier
+  date: Date
+  heure: string
+  equipeDomicileId: Identifier
+  equipeExterieurId: Identifier
+  officiels: Identifier[]
+  statut: string
+}
+
+export default class Match extends Entity<Properties> {
+  private constructor(props: Properties) {
+    super(props)
+  }
+
+  static create({
+    id,
+    date,
+    heure,
+    equipeDomicileId,
+    equipeExterieurId,
+    officiels,
+    statut,
+  }: {
+    id?: string
+    date: Date
+    heure: string
+    equipeDomicileId: string
+    equipeExterieurId: string
+    officiels?: string[]
+    statut?: string
+  }): Match {
+    return new Match({
+      id: id ? Identifier.fromString(id) : Identifier.generate(),
+      date,
+      heure,
+      equipeDomicileId: Identifier.fromString(equipeDomicileId),
+      equipeExterieurId: Identifier.fromString(equipeExterieurId),
+      officiels: (officiels ?? []).map((o) => Identifier.fromString(o)),
+      statut: statut ?? 'À venir',
+    })
+  }
+
+  get date() {
+    return this.props.date
+  }
+
+  get heure() {
+    return this.props.heure
+  }
+
+  get equipeDomicileId() {
+    return this.props.equipeDomicileId
+  }
+
+  get equipeExterieurId() {
+    return this.props.equipeExterieurId
+  }
+
+  get officiels() {
+    return this.props.officiels
+  }
+
+  get statut() {
+    return this.props.statut
+  }
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -32,7 +32,8 @@
     "#tests/*": "./tests/*.js",
     "#config/*": "./config/*.js",
     "#shared/*": "./app/shared/*.js",
-    "#auth/*": "./app/auth/*.js"
+    "#auth/*": "./app/auth/*.js",
+    "#match/*": "./app/modules/match/*.js"
   },
   "devDependencies": {
     "@adonisjs/assembler": "^7.8.2",

--- a/packages/backend/start/routes.ts
+++ b/packages/backend/start/routes.ts
@@ -64,4 +64,3 @@ router
     return { ok: true }
   })
   .use(middleware.auth(Role.ADMIN))
-

--- a/packages/backend/tests/functional/auth/auth_middleware.spec.ts
+++ b/packages/backend/tests/functional/auth/auth_middleware.spec.ts
@@ -8,7 +8,6 @@ process.env.JWT_EXPIRES_IN = '1h'
 const tokenProvider = new JwtTokenProvider()
 
 test.group('AuthMiddleware', () => {
-
   test("autorise l'accès pour un rôle présent", async ({ client }) => {
     const token = tokenProvider.generate({ roles: [Role.ADMIN] })
     const response = await client.get('/admin').header('Authorization', `Bearer ${token}`).send()

--- a/packages/backend/tests/unit/match/domain/match.spec.ts
+++ b/packages/backend/tests/unit/match/domain/match.spec.ts
@@ -1,0 +1,31 @@
+import { test } from '@japa/runner'
+import Match from '#match/domain/match'
+
+const equipeHome = '11111111-1111-1111-1111-111111111111'
+const equipeAway = '22222222-2222-2222-2222-222222222222'
+const official = '33333333-3333-3333-3333-333333333333'
+
+test.group('Match.create', () => {
+  test('devrait créer un match valide', ({ assert }) => {
+    const date = new Date('2025-01-01')
+    const heure = '12:30'
+
+    const match = Match.create({
+      date,
+      heure,
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+      officiels: [official],
+    })
+
+    assert.equal(match.date, date)
+    assert.equal(match.heure, heure)
+    assert.equal(match.equipeDomicileId.toString(), equipeHome)
+    assert.equal(match.equipeExterieurId.toString(), equipeAway)
+    assert.deepEqual(
+      match.officiels.map((id) => id.toString()),
+      [official]
+    )
+    assert.equal(match.statut, 'À venir')
+  })
+})


### PR DESCRIPTION
## Summary
- define `Match` entity under modules/match domain
- expose `#match/*` import alias
- clean up trailing newlines in routes and middleware spec
- add basic unit test for Match creation

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: No overload matches this call)*
- `npm test` *(fails: Cannot open database because the directory does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685152e9dca88329ad6b5242b105113d