### PR TITLE
Add match lifecycle methods

### DIFF
--- a/packages/backend/app/modules/match/domain/match.ts
+++ b/packages/backend/app/modules/match/domain/match.ts
@@ -1,6 +1,8 @@
 import { Entity } from '#shared/domaine/entity'
 import { Identifier } from '#shared/domaine/identifier'
 import InvalidMatchException from '#match/exceptions/invalid_match_exception'
+import InvalidMatchStateException from '#match/exceptions/invalid_match_state_exception'
+import { StatutMatch, allStatutMatch, allowedTransitions } from '#match/domain/statut_match'
 
 interface Properties {
   id: Identifier
@@ -9,7 +11,11 @@ interface Properties {
   equipeDomicileId: Identifier
   equipeExterieurId: Identifier
   officiels: Identifier[]
-  statut: string
+  statut: StatutMatch
+  motifAnnulation?: string
+  motifReport?: string
+  scoreDomicile?: number
+  scoreExterieur?: number
 }
 
 export default class Match extends Entity<Properties> {
@@ -32,7 +38,7 @@ export default class Match extends Entity<Properties> {
     equipeDomicileId: string
     equipeExterieurId: string
     officiels?: string[]
-    statut?: string
+    statut?: StatutMatch
   }): Match {
     if (!date || Number.isNaN(date.getTime())) {
       throw new InvalidMatchException('Date du match invalide')
@@ -57,7 +63,7 @@ export default class Match extends Entity<Properties> {
       equipeDomicileId: Identifier.fromString(equipeDomicileId),
       equipeExterieurId: Identifier.fromString(equipeExterieurId),
       officiels: (officiels ?? []).map((o) => Identifier.fromString(o)),
-      statut: statut ?? 'À venir',
+      statut: statut ?? StatutMatch.A_VENIR,
     })
   }
 
@@ -83,5 +89,109 @@ export default class Match extends Entity<Properties> {
 
   get statut() {
     return this.props.statut
+  }
+
+  changerStatut(nouveauStatut: StatutMatch) {
+    if (!allStatutMatch.has(nouveauStatut)) {
+      throw new InvalidMatchStateException(`Statut inconnu : ${nouveauStatut}`)
+    }
+
+    const autorises = allowedTransitions[this.props.statut] || []
+    if (!autorises.includes(nouveauStatut)) {
+      throw new InvalidMatchStateException(
+        `Transition de ${this.props.statut} vers ${nouveauStatut} interdite`
+      )
+    }
+
+    this.props.statut = nouveauStatut
+  }
+
+  affecterOfficiels(officiels: string[]) {
+    if (!officiels || officiels.length === 0) {
+      throw new InvalidMatchStateException('La liste des officiels est vide')
+    }
+
+    const uniques = Array.from(new Set(officiels))
+    this.props.officiels = uniques.map((o) => Identifier.fromString(o))
+  }
+
+  private validateDateHeure(date: Date, heure: string) {
+    if (!date || Number.isNaN(date.getTime())) {
+      throw new InvalidMatchStateException('Date du match invalide')
+    }
+    if (!heure || !/^([01]?\d|2[0-3]):[0-5]\d$/.test(heure)) {
+      throw new InvalidMatchStateException('Heure du match invalide')
+    }
+
+    const [h, m] = heure.split(':').map((v) => Number(v))
+    const datetime = new Date(date)
+    datetime.setHours(h, m, 0, 0)
+    if (datetime.getTime() <= Date.now()) {
+      throw new InvalidMatchStateException('La date doit être future')
+    }
+  }
+
+  modifierHoraire(nouvelleDate: Date, nouvelleHeure: string) {
+    this.validateDateHeure(nouvelleDate, nouvelleHeure)
+    this.props.date = nouvelleDate
+    this.props.heure = nouvelleHeure
+    this.props.motifReport = undefined
+    if (this.props.statut !== StatutMatch.A_VENIR) {
+      this.changerStatut(StatutMatch.A_VENIR)
+    }
+  }
+
+  annulerMatch(motif: string) {
+    if (!motif || motif.trim().length === 0) {
+      throw new InvalidMatchStateException('Le motif est requis pour annuler')
+    }
+    this.props.motifAnnulation = motif
+    this.changerStatut(StatutMatch.ANNULE)
+  }
+
+  reporterMatch(nouvelleDate: Date, nouvelleHeure: string, motif: string) {
+    if (!motif || motif.trim().length === 0) {
+      throw new InvalidMatchStateException('Le motif est requis pour reporter')
+    }
+    this.validateDateHeure(nouvelleDate, nouvelleHeure)
+    this.props.date = nouvelleDate
+    this.props.heure = nouvelleHeure
+    this.props.motifReport = motif
+    this.changerStatut(StatutMatch.REPORTE)
+  }
+
+  demarrerMatch() {
+    if (![StatutMatch.A_VENIR, StatutMatch.REPORTE].includes(this.props.statut)) {
+      throw new InvalidMatchStateException(
+        `Impossible de démarrer le match depuis le statut ${this.props.statut}`
+      )
+    }
+
+    const [h, m] = this.props.heure.split(':').map((v) => Number(v))
+    const datetime = new Date(this.props.date)
+    datetime.setHours(h, m, 0, 0)
+    if (datetime.getTime() > Date.now()) {
+      throw new InvalidMatchStateException("L'heure de début du match n'est pas encore atteinte")
+    }
+
+    this.changerStatut(StatutMatch.EN_COURS)
+  }
+
+  terminerMatch(scoreDomicile: number, scoreExterieur: number) {
+    if (this.props.statut !== StatutMatch.EN_COURS) {
+      throw new InvalidMatchStateException('Le match doit être en cours pour être terminé')
+    }
+    if (
+      scoreDomicile === undefined ||
+      scoreExterieur === undefined ||
+      scoreDomicile < 0 ||
+      scoreExterieur < 0
+    ) {
+      throw new InvalidMatchStateException('Scores invalides')
+    }
+
+    this.props.scoreDomicile = scoreDomicile
+    this.props.scoreExterieur = scoreExterieur
+    this.changerStatut(StatutMatch.TERMINE)
   }
 }

--- a/packages/backend/app/modules/match/domain/statut_match.ts
+++ b/packages/backend/app/modules/match/domain/statut_match.ts
@@ -1,0 +1,17 @@
+export enum StatutMatch {
+  A_VENIR = 'À venir',
+  EN_COURS = 'En cours',
+  TERMINE = 'Terminé',
+  ANNULE = 'Annulé',
+  REPORTE = 'Reporté',
+}
+
+export const allStatutMatch = new Set(Object.values(StatutMatch))
+
+export const allowedTransitions: Record<StatutMatch, StatutMatch[]> = {
+  [StatutMatch.A_VENIR]: [StatutMatch.EN_COURS, StatutMatch.ANNULE, StatutMatch.REPORTE],
+  [StatutMatch.REPORTE]: [StatutMatch.A_VENIR, StatutMatch.EN_COURS, StatutMatch.ANNULE],
+  [StatutMatch.EN_COURS]: [StatutMatch.TERMINE],
+  [StatutMatch.TERMINE]: [],
+  [StatutMatch.ANNULE]: [],
+}

--- a/packages/backend/app/modules/match/exceptions/invalid_match_state_exception.ts
+++ b/packages/backend/app/modules/match/exceptions/invalid_match_state_exception.ts
@@ -1,0 +1,6 @@
+export default class InvalidMatchStateException extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidMatchStateException'
+  }
+}

--- a/packages/backend/tests/unit/match/domain/match.spec.ts
+++ b/packages/backend/tests/unit/match/domain/match.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '@japa/runner'
 import Match from '#match/domain/match'
+import { StatutMatch } from '#match/domain/statut_match'
 
 const equipeHome = '11111111-1111-1111-1111-111111111111'
 const equipeAway = '22222222-2222-2222-2222-222222222222'
@@ -26,7 +27,7 @@ test.group('Match.create', () => {
       match.officiels.map((id) => id.toString()),
       [official]
     )
-    assert.equal(match.statut, 'À venir')
+    assert.equal(match.statut, StatutMatch.A_VENIR)
   })
 
   test('devrait échouer si les équipes sont identiques', ({ assert }) => {
@@ -97,5 +98,125 @@ test.group('Match.create', () => {
         equipeExterieurId: equipeAway,
       })
     }, 'Heure du match invalide')
+  })
+})
+
+test.group('Match methods', () => {
+  test('changerStatut devrait accepter une transition valide', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    match.changerStatut(StatutMatch.REPORTE)
+
+    assert.equal(match.statut, StatutMatch.REPORTE)
+  })
+
+  test('changerStatut devrait refuser une transition interdite', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+      statut: StatutMatch.TERMINE,
+    })
+
+    assert.throws(
+      () => match.changerStatut(StatutMatch.EN_COURS),
+      'Transition de Terminé vers En cours interdite'
+    )
+  })
+
+  test('affecterOfficiels devrait mettre à jour les officiels', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    match.affecterOfficiels([official])
+
+    assert.deepEqual(
+      match.officiels.map((o) => o.toString()),
+      [official]
+    )
+  })
+
+  test('modifierHoraire devrait changer date et heure', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    const newDate = new Date(Date.now() + 86_400_000)
+    match.modifierHoraire(newDate, '14:00')
+
+    assert.equal(match.date, newDate)
+    assert.equal(match.heure, '14:00')
+    assert.equal(match.statut, StatutMatch.A_VENIR)
+  })
+
+  test('annulerMatch devrait mettre le statut à ANNULE', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    match.annulerMatch('pluie')
+
+    assert.equal(match.statut, StatutMatch.ANNULE)
+  })
+
+  test('reporterMatch devrait définir une nouvelle date et le statut', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    const newDate = new Date(Date.now() + 172_800_000)
+    match.reporterMatch(newDate, '16:00', 'terrain indisponible')
+
+    assert.equal(match.date, newDate)
+    assert.equal(match.heure, '16:00')
+    assert.equal(match.statut, StatutMatch.REPORTE)
+  })
+
+  test('demarrerMatch devrait passer le statut à EN_COURS', ({ assert }) => {
+    const date = new Date(Date.now() - 3600_000)
+    const match = Match.create({
+      date,
+      heure: '00:00',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    match.demarrerMatch()
+
+    assert.equal(match.statut, StatutMatch.EN_COURS)
+  })
+
+  test('terminerMatch devrait enregistrer le score', ({ assert }) => {
+    const date = new Date(Date.now() - 3600_000)
+    const match = Match.create({
+      date,
+      heure: '00:00',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    match.demarrerMatch()
+    match.terminerMatch(2, 1)
+
+    assert.equal(match.statut, StatutMatch.TERMINE)
   })
 })


### PR DESCRIPTION
## Summary
- add `StatutMatch` enum and allowed transitions
- add `InvalidMatchStateException`
- implement lifecycle methods in `Match` domain entity
- cover new behaviours with unit tests

## Testing
- `yarn workspace backend format`
- `JWT_SECRET=test JWT_EXPIRES_IN=1h yarn workspace backend test`

------
https://chatgpt.com/codex/tasks/task_e_685161a2316c83299c632159273eebcc