### PR TITLE
Add extensive match entity unit tests

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,8 +8,8 @@
     "start": "node bin/server.js",
     "build": "node ace build",
     "dev": "node ace serve --hmr",
-    "test": "APP_KEY=abcdefghijklmnopabcdefghijklmnop node ace test --reporters=spec",
-    "coverage": "APP_KEY=abcdefghijklmnopabcdefghijklmnop c8 --all -n app --reporters=lcov node ace test",
+    "test": "APP_KEY=abcdefghijklmnopabcdefghijklmnop JWT_SECRET=secret JWT_EXPIRES_IN=1h node ace test --reporters=spec",
+    "coverage": "APP_KEY=abcdefghijklmnopabcdefghijklmnop JWT_SECRET=secret JWT_EXPIRES_IN=1h c8 --all -n app --reporters=lcov node ace test",
     "lint": "eslint .",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit"

--- a/packages/backend/tests/bootstrap.ts
+++ b/packages/backend/tests/bootstrap.ts
@@ -4,6 +4,7 @@ import app from '@adonisjs/core/services/app'
 import type { Config } from '@japa/runner/types'
 import { pluginAdonisJS } from '@japa/plugin-adonisjs'
 import testUtils from '@adonisjs/core/services/test_utils'
+import fs from 'node:fs'
 
 process.env.JWT_SECRET = 'testsecret'
 process.env.JWT_EXPIRES_IN = '1h'
@@ -26,7 +27,7 @@ export const plugins: Config['plugins'] = [assert(), apiClient(), pluginAdonisJS
  * The teardown functions are executed after all the tests
  */
 export const runnerHooks: Required<Pick<Config, 'setup' | 'teardown'>> = {
-  setup: [],
+  setup: [() => fs.mkdirSync(app.tmpPath(), { recursive: true })],
   teardown: [],
 }
 

--- a/packages/backend/tests/unit/match/domain/match.spec.ts
+++ b/packages/backend/tests/unit/match/domain/match.spec.ts
@@ -30,6 +30,19 @@ test.group('Match.create', () => {
     assert.equal(match.statut, StatutMatch.A_VENIR)
   })
 
+  test('devrait accepter un id fourni', ({ assert }) => {
+    const id = '44444444-4444-4444-4444-444444444444'
+    const match = Match.create({
+      id,
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.equal(match.id.toString(), id)
+  })
+
   test('devrait échouer si les équipes sont identiques', ({ assert }) => {
     const date = new Date('2025-01-01')
     const heure = '12:30'
@@ -130,6 +143,17 @@ test.group('Match methods', () => {
     )
   })
 
+  test('changerStatut devrait refuser un statut inconnu', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(() => match.changerStatut('INCONNU' as any), 'Statut inconnu')
+  })
+
   test('affecterOfficiels devrait mettre à jour les officiels', ({ assert }) => {
     const match = Match.create({
       date: new Date('2025-01-01'),
@@ -144,6 +168,30 @@ test.group('Match methods', () => {
       match.officiels.map((o) => o.toString()),
       [official]
     )
+  })
+
+  test('affecterOfficiels devrait dédupliquer les officiels', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    match.affecterOfficiels([official, official])
+
+    assert.lengthOf(match.officiels, 1)
+  })
+
+  test('affecterOfficiels devrait refuser une liste vide', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(() => match.affecterOfficiels([]), 'La liste des officiels est vide')
   })
 
   test('modifierHoraire devrait changer date et heure', ({ assert }) => {
@@ -162,6 +210,63 @@ test.group('Match methods', () => {
     assert.equal(match.statut, StatutMatch.A_VENIR)
   })
 
+  test('modifierHoraire devrait refuser une date passée', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(
+      () => match.modifierHoraire(new Date(Date.now() - 1000), '00:00'),
+      'La date doit être future'
+    )
+  })
+
+  test('modifierHoraire devrait refuser une heure invalide', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(
+      () => match.modifierHoraire(new Date(Date.now() + 86_400_000), '99:99'),
+      'Heure du match invalide'
+    )
+  })
+
+  test('modifierHoraire devrait refuser une date invalide', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(
+      () => match.modifierHoraire(new Date('invalid-date'), '12:00'),
+      'Date du match invalide'
+    )
+  })
+
+  test('modifierHoraire remet le statut à A_VENIR', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    const newDate = new Date(Date.now() + 172_800_000)
+    match.changerStatut(StatutMatch.REPORTE)
+    match.modifierHoraire(newDate, '18:00')
+
+    assert.equal(match.statut, StatutMatch.A_VENIR)
+  })
+
   test('annulerMatch devrait mettre le statut à ANNULE', ({ assert }) => {
     const match = Match.create({
       date: new Date('2025-01-01'),
@@ -173,6 +278,17 @@ test.group('Match methods', () => {
     match.annulerMatch('pluie')
 
     assert.equal(match.statut, StatutMatch.ANNULE)
+  })
+
+  test('annulerMatch devrait refuser un motif vide', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(() => match.annulerMatch(''), 'Le motif est requis pour annuler')
   })
 
   test('reporterMatch devrait définir une nouvelle date et le statut', ({ assert }) => {
@@ -191,6 +307,63 @@ test.group('Match methods', () => {
     assert.equal(match.statut, StatutMatch.REPORTE)
   })
 
+  test('reporterMatch devrait refuser un motif vide', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    const newDate = new Date(Date.now() + 172_800_000)
+
+    assert.throws(
+      () => match.reporterMatch(newDate, '16:00', ''),
+      'Le motif est requis pour reporter'
+    )
+  })
+
+  test('reporterMatch devrait refuser une date passée', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(
+      () => match.reporterMatch(new Date(Date.now() - 1000), '00:00', 'motif'),
+      'La date doit être future'
+    )
+  })
+
+  test('reporterMatch devrait refuser une date invalide', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(
+      () => match.reporterMatch(new Date('invalid-date'), '12:00', 'motif'),
+      'Date du match invalide'
+    )
+  })
+
+  test('reporterMatch devrait refuser une heure invalide', ({ assert }) => {
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:30',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    const future = new Date(Date.now() + 86_400_000)
+
+    assert.throws(() => match.reporterMatch(future, '99:99', 'motif'), 'Heure du match invalide')
+  })
+
   test('demarrerMatch devrait passer le statut à EN_COURS', ({ assert }) => {
     const date = new Date(Date.now() - 3600_000)
     const match = Match.create({
@@ -203,6 +376,36 @@ test.group('Match methods', () => {
     match.demarrerMatch()
 
     assert.equal(match.statut, StatutMatch.EN_COURS)
+  })
+
+  test('demarrerMatch devrait refuser un statut invalide', ({ assert }) => {
+    const match = Match.create({
+      date: new Date(Date.now() - 3600_000),
+      heure: '00:00',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    match.changerStatut(StatutMatch.ANNULE)
+
+    assert.throws(
+      () => match.demarrerMatch(),
+      'Impossible de démarrer le match depuis le statut Annulé'
+    )
+  })
+
+  test("demarrerMatch devrait refuser si l'heure n'est pas atteinte", ({ assert }) => {
+    const match = Match.create({
+      date: new Date(Date.now() + 86_400_000),
+      heure: '23:59',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(
+      () => match.demarrerMatch(),
+      "L'heure de début du match n'est pas encore atteinte"
+    )
   })
 
   test('terminerMatch devrait enregistrer le score', ({ assert }) => {
@@ -218,5 +421,29 @@ test.group('Match methods', () => {
     match.terminerMatch(2, 1)
 
     assert.equal(match.statut, StatutMatch.TERMINE)
+  })
+
+  test('terminerMatch devrait refuser si le match nest pas en cours', ({ assert }) => {
+    const match = Match.create({
+      date: new Date(Date.now() - 3600_000),
+      heure: '00:00',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    assert.throws(() => match.terminerMatch(1, 1), 'Le match doit être en cours')
+  })
+
+  test('terminerMatch devrait refuser des scores invalides', ({ assert }) => {
+    const match = Match.create({
+      date: new Date(Date.now() - 3600_000),
+      heure: '00:00',
+      equipeDomicileId: equipeHome,
+      equipeExterieurId: equipeAway,
+    })
+
+    match.demarrerMatch()
+
+    assert.throws(() => match.terminerMatch(-1, 0), 'Scores invalides')
   })
 })


### PR DESCRIPTION
## Summary
- update test scripts to set JWT vars
- ensure tmp folder exists when running tests
- extend match entity tests for full coverage

## Testing
- `yarn format`
- `yarn test`
- `yarn coverage`

------
https://chatgpt.com/codex/tasks/task_e_685168296c48832981039680c888dc54