### PR TITLE
Add GetMatches use case

### DIFF
--- a/packages/backend/app/modules/match/secondary/ports/match_repository.ts
+++ b/packages/backend/app/modules/match/secondary/ports/match_repository.ts
@@ -1,0 +1,12 @@
+import Match from '#match/domain/match'
+
+export interface MatchSearchCriteria {
+  startDate?: Date
+  endDate?: Date
+  equipeId?: string
+  officielId?: string
+}
+
+export interface MatchRepository {
+  search(criteria: MatchSearchCriteria): Promise<Match[]>
+}

--- a/packages/backend/app/modules/match/service/get_matches.ts
+++ b/packages/backend/app/modules/match/service/get_matches.ts
@@ -1,0 +1,11 @@
+import Match from '#match/domain/match'
+import { MatchRepository } from '#match/secondary/ports/match_repository'
+import { GetMatchesFilter, GetMatchesUseCase } from '#match/use_case/get_matches_use_case'
+
+export class GetMatches implements GetMatchesUseCase {
+  constructor(private readonly matchRepository: MatchRepository) {}
+
+  async execute(filters: GetMatchesFilter = {}): Promise<Match[]> {
+    return this.matchRepository.search(filters)
+  }
+}

--- a/packages/backend/app/modules/match/use_case/get_matches_use_case.ts
+++ b/packages/backend/app/modules/match/use_case/get_matches_use_case.ts
@@ -1,0 +1,12 @@
+import Match from '#match/domain/match'
+
+export interface GetMatchesFilter {
+  startDate?: Date
+  endDate?: Date
+  equipeId?: string
+  officielId?: string
+}
+
+export interface GetMatchesUseCase {
+  execute(filters?: GetMatchesFilter): Promise<Match[]>
+}

--- a/packages/backend/tests/unit/match/stubs/stub_match_repository.ts
+++ b/packages/backend/tests/unit/match/stubs/stub_match_repository.ts
@@ -1,0 +1,27 @@
+import Match from '#match/domain/match'
+import { MatchRepository, MatchSearchCriteria } from '#match/secondary/ports/match_repository'
+
+export class StubMatchRepository implements MatchRepository {
+  constructor(private matches: Match[] = []) {}
+
+  async search(criteria: MatchSearchCriteria): Promise<Match[]> {
+    return this.matches.filter((m) => {
+      if (criteria.startDate && m.date.getTime() < criteria.startDate.getTime()) {
+        return false
+      }
+      if (criteria.endDate && m.date.getTime() > criteria.endDate.getTime()) {
+        return false
+      }
+      if (
+        criteria.equipeId &&
+        ![m.equipeDomicileId.toString(), m.equipeExterieurId.toString()].includes(criteria.equipeId)
+      ) {
+        return false
+      }
+      if (criteria.officielId && !m.officiels.some((o) => o.toString() === criteria.officielId)) {
+        return false
+      }
+      return true
+    })
+  }
+}

--- a/packages/backend/tests/unit/match/use_case/get_matches.spec.ts
+++ b/packages/backend/tests/unit/match/use_case/get_matches.spec.ts
@@ -1,0 +1,76 @@
+import { test } from '@japa/runner'
+import Match from '#match/domain/match'
+import { GetMatches } from '#match/service/get_matches'
+import { StubMatchRepository } from '#tests/unit/match/stubs/stub_match_repository'
+
+const equipeHome = '11111111-1111-1111-1111-111111111111'
+const equipeAway = '22222222-2222-2222-2222-222222222222'
+const official = '33333333-3333-3333-3333-333333333333'
+
+function createMatch(date: string, heure = '12:00', officials: string[] = [official]) {
+  return Match.create({
+    date: new Date(date),
+    heure,
+    equipeDomicileId: equipeHome,
+    equipeExterieurId: equipeAway,
+    officiels: officials,
+  })
+}
+
+test.group('GetMatches', () => {
+  test('devrait filtrer par plage de dates', async ({ assert }) => {
+    const match1 = createMatch('2025-01-01')
+    const match2 = createMatch('2025-01-02')
+    const match3 = createMatch('2025-01-03')
+    const repo = new StubMatchRepository([match1, match2, match3])
+    const usecase = new GetMatches(repo)
+
+    const result = await usecase.execute({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+
+    assert.lengthOf(result, 2)
+    assert.deepEqual(
+      result.map((m) => m.id.toString()),
+      [match1.id.toString(), match2.id.toString()]
+    )
+  })
+
+  test('devrait retourner vide si aucun match ne correspond', async ({ assert }) => {
+    const match1 = createMatch('2025-01-01')
+    const repo = new StubMatchRepository([match1])
+    const usecase = new GetMatches(repo)
+
+    const result = await usecase.execute({ officielId: 'unknown' })
+
+    assert.deepEqual(result, [])
+  })
+
+  test('devrait retourner tous les matchs sans filtre', async ({ assert }) => {
+    const match1 = createMatch('2025-01-01')
+    const match2 = createMatch('2025-01-02')
+    const repo = new StubMatchRepository([match1, match2])
+    const usecase = new GetMatches(repo)
+
+    const result = await usecase.execute()
+
+    assert.lengthOf(result, 2)
+  })
+
+  test('devrait filtrer par critères multiples', async ({ assert }) => {
+    const match1 = createMatch('2025-01-01')
+    const match2 = createMatch('2025-01-01', '14:00', ['44444444-4444-4444-4444-444444444444'])
+    const repo = new StubMatchRepository([match1, match2])
+    const usecase = new GetMatches(repo)
+
+    const result = await usecase.execute({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-01'),
+      officielId: official,
+    })
+
+    assert.lengthOf(result, 1)
+    assert.equal(result[0].id.toString(), match1.id.toString())
+  })
+})


### PR DESCRIPTION
## Summary
- create match repository port
- add GetMatches service and use case definition
- provide test stub for match repository
- cover GetMatches logic with unit tests
- allow filtering matches by date range

## Testing
- `yarn workspace backend format`
- `JWT_SECRET=testsecret JWT_EXPIRES_IN=1h yarn workspace backend test`


------
https://chatgpt.com/codex/tasks/task_e_6851685afef88329a802820a2849546b