### PR TITLE
Implement MatchRepository interface

### DIFF
--- a/packages/backend/app/modules/match/secondary/ports/match_repository.ts
+++ b/packages/backend/app/modules/match/secondary/ports/match_repository.ts
@@ -1,12 +1,36 @@
 import Match from '#match/domain/match'
 
+/**
+ * Ensemble de critères permettant de rechercher des matchs.
+ * Tous les champs sont optionnels et peuvent être combinés.
+ */
 export interface MatchSearchCriteria {
+  /** Date minimale du match (inclus). */
   startDate?: Date
+  /** Date maximale du match (inclus). */
   endDate?: Date
+  /** Identifiant d'une équipe concernée par le match. */
   equipeId?: string
+  /** Identifiant d'un officiel assigné au match. */
   officielId?: string
 }
 
+/**
+ * Port d'accès aux données Match.
+ * Fournit les méthodes de récupération des matchs pour la couche Domaine.
+ */
 export interface MatchRepository {
-  search(criteria: MatchSearchCriteria): Promise<Match[]>
+  /**
+   * Retourne l'ensemble des matchs disponibles.
+   */
+  findAll(): Promise<Match[]>
+
+  /**
+   * Recherche des matchs correspondant aux critères spécifiés.
+   * Les critères non renseignés sont ignorés.
+   *
+   * @param criteria — filtres optionnels sur la période, les équipes ou les officiels.
+   * @returns La liste des matchs satisfaisant les critères.
+   */
+  findByCriteria(criteria: MatchSearchCriteria): Promise<Match[]>
 }

--- a/packages/backend/app/modules/match/service/get_matches.ts
+++ b/packages/backend/app/modules/match/service/get_matches.ts
@@ -6,6 +6,9 @@ export class GetMatches implements GetMatchesUseCase {
   constructor(private readonly matchRepository: MatchRepository) {}
 
   async execute(filters: GetMatchesFilter = {}): Promise<Match[]> {
-    return this.matchRepository.search(filters)
+    if (Object.keys(filters).length === 0) {
+      return this.matchRepository.findAll()
+    }
+    return this.matchRepository.findByCriteria(filters)
   }
 }

--- a/packages/backend/tests/unit/match/stubs/stub_match_repository.ts
+++ b/packages/backend/tests/unit/match/stubs/stub_match_repository.ts
@@ -4,7 +4,11 @@ import { MatchRepository, MatchSearchCriteria } from '#match/secondary/ports/mat
 export class StubMatchRepository implements MatchRepository {
   constructor(private matches: Match[] = []) {}
 
-  async search(criteria: MatchSearchCriteria): Promise<Match[]> {
+  async findAll(): Promise<Match[]> {
+    return [...this.matches]
+  }
+
+  async findByCriteria(criteria: MatchSearchCriteria): Promise<Match[]> {
     return this.matches.filter((m) => {
       if (criteria.startDate && m.date.getTime() < criteria.startDate.getTime()) {
         return false


### PR DESCRIPTION
## Summary
- add detailed `MatchRepository` interface with `findAll` and `findByCriteria`
- update `GetMatches` service to use new repository methods
- adjust stub repository accordingly

## Testing
- `yarn workspace backend format`
- `yarn workspace backend test`


------
https://chatgpt.com/codex/tasks/task_e_6851711b16ac832992f5ede28fce5d11