### PR TITLE
Add Bruno request files for backend routes

### DIFF
--- a/packages/backend/bruno/environments/local.json
+++ b/packages/backend/bruno/environments/local.json
@@ -1,0 +1,9 @@
+{
+  "meta": {
+    "name": "Local",
+    "default": true
+  },
+  "data": {
+    "baseUrl": "http://localhost:3333"
+  }
+}

--- a/packages/backend/bruno/requests/admin.bru
+++ b/packages/backend/bruno/requests/admin.bru
@@ -1,0 +1,12 @@
+meta:
+  name: Admin
+  type: http
+  version: 1
+request:
+  url: "{{baseUrl}}/admin"
+  method: GET
+  headers:
+    - key: Authorization
+      value: Bearer <token>
+auth:
+  type: none

--- a/packages/backend/bruno/requests/login.bru
+++ b/packages/backend/bruno/requests/login.bru
@@ -1,0 +1,19 @@
+meta:
+  name: Login
+  type: http
+  version: 1
+request:
+  url: "{{baseUrl}}/api/auth/login"
+  method: POST
+  headers:
+    - key: Content-Type
+      value: application/json
+  body:
+    type: json
+    json: |
+      {
+        "email": "user@example.com",
+        "password": "password"
+      }
+auth:
+  type: none

--- a/packages/backend/bruno/requests/register.bru
+++ b/packages/backend/bruno/requests/register.bru
@@ -1,0 +1,19 @@
+meta:
+  name: Register
+  type: http
+  version: 1
+request:
+  url: "{{baseUrl}}/api/auth/register"
+  method: POST
+  headers:
+    - key: Content-Type
+      value: application/json
+  body:
+    type: json
+    json: |
+      {
+        "email": "user@example.com",
+        "password": "password"
+      }
+auth:
+  type: none

--- a/packages/backend/bruno/requests/root.bru
+++ b/packages/backend/bruno/requests/root.bru
@@ -1,0 +1,10 @@
+meta:
+  name: Root
+  type: http
+  version: 1
+request:
+  url: "{{baseUrl}}/"
+  method: GET
+  headers: []
+auth:
+  type: none


### PR DESCRIPTION
## Summary
- add Bruno workspace under `packages/backend/bruno`
- provide basic request examples for login, register, root, admin
- provide local environment configuration for Bruno

## Testing
- `yarn test` *(fails: fetch failed)*
- `yarn format` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851873042508329893f8364b94beba8