### PR TITLE
Add CSV import endpoint

### DIFF
--- a/packages/backend/app/modules/importer/index.ts
+++ b/packages/backend/app/modules/importer/index.ts
@@ -1,0 +1,4 @@
+import { UploadCsvUseCase } from '#importer/use_case/upload_csv_use_case'
+import { UploadCsvService } from '#importer/service/upload_csv_service'
+
+export const importerProviderMap = [[UploadCsvUseCase, UploadCsvService]]

--- a/packages/backend/app/modules/importer/primary/http/upload_csv_controller.ts
+++ b/packages/backend/app/modules/importer/primary/http/upload_csv_controller.ts
@@ -1,0 +1,18 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { UploadCsvUseCase } from '#importer/use_case/upload_csv_use_case'
+
+@inject()
+export default class UploadCsvController {
+  constructor(private readonly useCase: UploadCsvUseCase) {}
+
+  async handle({ request, response }: HttpContext) {
+    const file = request.file('file')
+    if (!file) {
+      return response.badRequest({ error: 'file is required' })
+    }
+
+    await this.useCase.execute(file)
+    return response.created({ uploaded: true })
+  }
+}

--- a/packages/backend/app/modules/importer/service/upload_csv_service.ts
+++ b/packages/backend/app/modules/importer/service/upload_csv_service.ts
@@ -1,0 +1,19 @@
+import { UploadCsvUseCase } from '#importer/use_case/upload_csv_use_case'
+import type { MultipartFile } from '@adonisjs/bodyparser'
+import { promises as fs } from 'node:fs'
+
+export class UploadCsvService extends UploadCsvUseCase {
+  async execute(file: MultipartFile): Promise<void> {
+    if (!file || !file.isMultipartFile) {
+      throw new Error('Fichier manquant')
+    }
+    if (file.extname !== 'csv') {
+      throw new Error('Format de fichier invalide')
+    }
+    if (!file.tmpPath) {
+      throw new Error("Le fichier n'a pas été traité")
+    }
+
+    await fs.readFile(file.tmpPath)
+  }
+}

--- a/packages/backend/app/modules/importer/use_case/upload_csv_use_case.ts
+++ b/packages/backend/app/modules/importer/use_case/upload_csv_use_case.ts
@@ -1,0 +1,3 @@
+export abstract class UploadCsvUseCase {
+  abstract execute(file: import('@adonisjs/bodyparser').MultipartFile): Promise<void>
+}

--- a/packages/backend/app/modules/match/index.ts
+++ b/packages/backend/app/modules/match/index.ts
@@ -1,4 +1,9 @@
 import { GetMatchesUseCase } from '#match/use_case/get_matches_use_case'
 import { GetMatches } from '#match/service/get_matches'
+import { MatchRepository } from '#match/secondary/ports/match_repository'
+import { LucidMatchRepository } from '#match/secondary/adapters/lucid_match_repository'
 
-export const matchProviderMap = [[GetMatchesUseCase], [GetMatchesUseCase, GetMatches]]
+export const matchProviderMap = [
+  [GetMatchesUseCase, GetMatches],
+  [MatchRepository, LucidMatchRepository],
+]

--- a/packages/backend/app/modules/match/primary/http/get_matches_controller.ts
+++ b/packages/backend/app/modules/match/primary/http/get_matches_controller.ts
@@ -1,12 +1,12 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { getMatchesValidator } from '#match/primary/http/get_matches_validator'
-import type { GetMatchesUseCase } from '#match/use_case/get_matches_use_case'
+import { GetMatchesUseCase } from '#match/use_case/get_matches_use_case'
 import { inject } from '@adonisjs/core'
 
+@inject()
 export default class GetMatchesController {
   constructor(private readonly useCase: GetMatchesUseCase) {}
 
-  @inject()
   async handle({ request, response }: HttpContext) {
     const payload = await getMatchesValidator.validate(request.qs())
     const matches = await this.useCase.execute(payload)

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,7 +33,8 @@
     "#config/*": "./config/*.js",
     "#shared/*": "./app/shared/*.js",
     "#auth/*": "./app/auth/*.js",
-    "#match/*": "./app/modules/match/*.js"
+    "#match/*": "./app/modules/match/*.js",
+    "#importer/*": "./app/modules/importer/*.js"
   },
   "devDependencies": {
     "@adonisjs/assembler": "^7.8.2",

--- a/packages/backend/providers/app_provider.ts
+++ b/packages/backend/providers/app_provider.ts
@@ -1,6 +1,7 @@
 import type { ApplicationService } from '@adonisjs/core/types'
 import { authProviderMap } from '#auth/index'
 import { matchProviderMap } from '#match/index'
+import { importerProviderMap } from '#importer/index'
 
 export default class AppProvider {
   constructor(protected app: ApplicationService) {}
@@ -14,10 +15,12 @@ export default class AppProvider {
    * The container bindings have booted
    */
   async boot() {
-    const sources = [matchProviderMap, authProviderMap]
-    sources.flat().forEach(([useCase, service]) => {
-      this.app.container.bind(useCase, () => {
-        return this.app.container.make(service)
+    const sources = [matchProviderMap, authProviderMap, importerProviderMap]
+    sources.forEach((map) => {
+      map.forEach(([useCase, service]) => {
+        this.app.container.bind(useCase, () => {
+          return this.app.container.make(service)
+        })
       })
     })
   }

--- a/packages/backend/start/routes.ts
+++ b/packages/backend/start/routes.ts
@@ -13,8 +13,8 @@ import { middleware } from '#start/kernel'
 
 const loginController = () => import('#auth/primary/http/login_controller')
 const registerController = () => import('#auth/primary/http/register_controller')
-const getMatchesController = () =>
-  import('../app/modules/match/primary/http/get_matches_controller')
+const getMatchesController = () => import('#match/primary/http/get_matches_controller')
+const uploadCsvController = () => import('#importer/primary/http/upload_csv_controller')
 
 router.post('/api/auth/register', [registerController])
 
@@ -33,3 +33,5 @@ router
   .use(middleware.auth(Role.ADMIN))
 
 router.get('/api/matches', [getMatchesController])
+
+router.post('/api/import/csv', [uploadCsvController])

--- a/packages/backend/tests/functional/importer/upload_csv_controller.spec.ts
+++ b/packages/backend/tests/functional/importer/upload_csv_controller.spec.ts
@@ -1,0 +1,16 @@
+import { test } from '@japa/runner'
+
+const sampleCsv = `semaine;num poule;competition;poule;J;le;horaire;club rec;club vis;club hote;arb1 designe;arb2 designe;observateur;delegue;code renc;nom salle;adresse salle;CP;Ville;colle;Coul. Rec;Coul. Gard. Rec;Coul. Vis;Coul. Gard. Vis;Ent. Rec;Tel Ent. Rec;Corresp. Rec;Tel Corresp. Rec;Ent. Vis;Tel Ent. Vis;Corresp. Vis;Tel Corresp. Vis;Num rec;Num vis\n2024-14;M624465072;u12m-44;U12M D8;7;07/04/2024;09/04/2024 14:30:00;HBC PORNIC;CHABOSSIERE OLYMPIQUE CLUB HB 2;HBC PORNIC;;;;;TAFEQMK;VAL SAINT MARTIN (SALLE 2); rue val saint martin;44210;PORNIC;Toutes colles interdites;Bleu;;Rouge-Noir;Jaune-Bleu;CHAUVET FRANCOISE;330668831514;CHAUVET FRANCOISE;330668831514;GUMIERO ELYO;330648677907;PASCAL MATHIEU;330616545866;6244036;6244011`
+
+test.group('UploadCsvController', () => {
+  test('uploads CSV file', async ({ client }) => {
+    const response = await client
+      .post('/api/import/csv')
+      .file('file', Buffer.from(sampleCsv), {
+        filename: 'matches.csv',
+        contentType: 'text/csv',
+      })
+      .send()
+    response.assertStatus(201)
+  })
+})


### PR DESCRIPTION
## Summary
- create importer module with hexagonal structure
- implement `UploadCsvService` to validate uploaded CSV
- expose POST `/api/import/csv` route
- bind importer module in `AppProvider`
- register `LucidMatchRepository` in match provider map
- add integration test for CSV upload

## Testing
- `yarn format`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68545b236f6c8329b90e952e415fff9d