### PR TITLE
Add CSV validation before import

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 HBManager facilite l'organisation des matchs de handball au sein des clubs en proposant :
 
-* **Import CSV** : ingestion automatique des rencontres via un fichier CSV conforme à la fédération.
+* **Import CSV** : ingestion automatique des rencontres via un fichier CSV conforme à la fédération. Un modèle est fourni dans `docs/csv_template.csv`.
 * **Calendrier interactif** : affichage des matchs passés et à venir, avec filtres par équipe, date et officiel.
 * **Gestion des équipes** : association domicile/extérieur pour chaque match.
 * **Gestion des officiels** : enregistrement et affectation des arbitres, scoreurs, chronométreurs.

--- a/docs/csv_template.csv
+++ b/docs/csv_template.csv
@@ -1,0 +1,2 @@
+le;horaire;club rec;club vis;nom salle
+2024-01-01;20:00;Equipe A;Equipe B;Gymnase

--- a/packages/backend/app/modules/importer/primary/http/upload_csv_controller.ts
+++ b/packages/backend/app/modules/importer/primary/http/upload_csv_controller.ts
@@ -12,7 +12,11 @@ export default class UploadCsvController {
       return response.badRequest({ error: 'file is required' })
     }
 
-    await this.useCase.execute(file)
-    return response.created({ uploaded: true })
+    try {
+      await this.useCase.execute(file)
+      return response.created({ uploaded: true })
+    } catch (error) {
+      return response.badRequest({ error: error.message, template: '/docs/csv_template.csv' })
+    }
   }
 }

--- a/packages/backend/tests/functional/importer/upload_csv_controller.spec.ts
+++ b/packages/backend/tests/functional/importer/upload_csv_controller.spec.ts
@@ -13,4 +13,40 @@ test.group('UploadCsvController', () => {
       .send()
     response.assertStatus(201)
   })
+
+  test('rejects file larger than 5MB', async ({ client }) => {
+    const largeBuffer = Buffer.alloc(6 * 1024 * 1024, 'a')
+    const response = await client
+      .post('/api/import/csv')
+      .file('file', largeBuffer, {
+        filename: 'big.csv',
+        contentType: 'text/csv',
+      })
+      .send()
+    response.assertStatus(400)
+  })
+
+  test('rejects non UTF-8 encoding', async ({ client }) => {
+    const invalidBuffer = Buffer.from([0xff, 0xff])
+    const response = await client
+      .post('/api/import/csv')
+      .file('file', invalidBuffer, {
+        filename: 'enc.csv',
+        contentType: 'text/csv',
+      })
+      .send()
+    response.assertStatus(400)
+  })
+
+  test('rejects missing headers', async ({ client }) => {
+    const csv = `le;horaire;club rec;nom salle\n2024-01-01;10:00;A;Salle`
+    const response = await client
+      .post('/api/import/csv')
+      .file('file', Buffer.from(csv), {
+        filename: 'bad.csv',
+        contentType: 'text/csv',
+      })
+      .send()
+    response.assertStatus(400)
+  })
 })


### PR DESCRIPTION
## Summary
- validate CSV files in importer service
- return error messages from controller
- add CSV template sample
- document CSV template in README
- add tests for error scenarios

## Testing
- `yarn format`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6854628b26ec8329ae8a7268bc053734