### PR TITLE
Fix duplicate CI triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ name: CI Monorepo
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - 'packages/**'
       - '.github/workflows/ci.yml'


### PR DESCRIPTION
## Summary
- run CI `push` only on `main` branch to avoid duplicate runs with `pull_request`

## Testing
- `yarn format` *(from `packages/backend`)*
- `yarn test` *(from `packages/backend`)*

------
https://chatgpt.com/codex/tasks/task_e_685464e59bb4832988b796cfdca388ea