### PR TITLE
Add import report persistence and return report

### DIFF
--- a/packages/backend/app/modules/importer/domain/import_report.ts
+++ b/packages/backend/app/modules/importer/domain/import_report.ts
@@ -1,0 +1,11 @@
+export interface IgnoredLine {
+  lineNumber: number
+  content: string
+  reason: string
+}
+
+export interface CsvImportReport {
+  totalLines: number
+  importedCount: number
+  ignored: IgnoredLine[]
+}

--- a/packages/backend/app/modules/importer/index.ts
+++ b/packages/backend/app/modules/importer/index.ts
@@ -1,4 +1,9 @@
 import { UploadCsvUseCase } from '#importer/use_case/upload_csv_use_case'
 import { UploadCsvService } from '#importer/service/upload_csv_service'
+import { ImportReportRepository } from '#importer/secondary/ports/import_report_repository'
+import { FileImportReportRepository } from '#importer/secondary/adapters/file_import_report_repository'
 
-export const importerProviderMap = [[UploadCsvUseCase, UploadCsvService]]
+export const importerProviderMap = [
+  [UploadCsvUseCase, UploadCsvService],
+  [ImportReportRepository, FileImportReportRepository],
+]

--- a/packages/backend/app/modules/importer/primary/http/upload_csv_controller.ts
+++ b/packages/backend/app/modules/importer/primary/http/upload_csv_controller.ts
@@ -13,8 +13,8 @@ export default class UploadCsvController {
     }
 
     try {
-      await this.useCase.execute(file)
-      return response.created({ uploaded: true })
+      const report = await this.useCase.execute(file)
+      return response.created({ uploaded: true, report })
     } catch (error) {
       return response.badRequest({ error: error.message, template: '/docs/csv_template.csv' })
     }

--- a/packages/backend/app/modules/importer/secondary/adapters/file_import_report_repository.ts
+++ b/packages/backend/app/modules/importer/secondary/adapters/file_import_report_repository.ts
@@ -1,0 +1,12 @@
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import os from 'node:os'
+import { ImportReportRepository } from '#importer/secondary/ports/import_report_repository'
+import { CsvImportReport } from '#importer/domain/import_report'
+
+export class FileImportReportRepository implements ImportReportRepository {
+  async save(report: CsvImportReport): Promise<void> {
+    const filePath = join(os.tmpdir(), 'import_report.json')
+    await fs.writeFile(filePath, JSON.stringify(report, null, 2))
+  }
+}

--- a/packages/backend/app/modules/importer/secondary/ports/import_report_repository.ts
+++ b/packages/backend/app/modules/importer/secondary/ports/import_report_repository.ts
@@ -1,0 +1,5 @@
+import { CsvImportReport } from '#importer/domain/import_report'
+
+export abstract class ImportReportRepository {
+  abstract save(report: CsvImportReport): Promise<void>
+}

--- a/packages/backend/app/modules/importer/use_case/upload_csv_use_case.ts
+++ b/packages/backend/app/modules/importer/use_case/upload_csv_use_case.ts
@@ -1,3 +1,5 @@
+import { CsvImportReport } from '#importer/domain/import_report'
+
 export abstract class UploadCsvUseCase {
-  abstract execute(file: import('@adonisjs/bodyparser').MultipartFile): Promise<void>
+  abstract execute(file: import('@adonisjs/bodyparser').MultipartFile): Promise<CsvImportReport>
 }


### PR DESCRIPTION
## Summary
- define `CsvImportReport` interface
- create storage port and file adapter
- update `UploadCsvService` to generate report and persist it
- return the report via HTTP
- test new behaviour including stored JSON file

## Testing
- `yarn format`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68558c22f0848329a31e32bab7270a38