### PR TITLE
Add docs for cahier des charges and architecture

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,9 @@
+# Architecture du projet
+
+Ce dossier rassemble les schémas et explications sur l'architecture de HBManager.
+
+1. **Backend** : API REST construite avec AdonisJS.
+2. **Frontend** : application Vue 3 consommant l'API.
+3. **Base de données** : PostgreSQL pour stocker les données de match et les utilisateurs.
+
+Ces documents pourront être complétés à mesure de l'avancement du projet.

--- a/docs/cahier_des_charges.md
+++ b/docs/cahier_des_charges.md
@@ -1,0 +1,16 @@
+# Cahier des charges
+
+Ce document liste les objectifs fonctionnels et techniques de HBManager.
+
+## Objectifs principaux
+
+- Automatiser l'import des plannings issus de fichiers CSV fédéraux.
+- Gérer la planification des matchs et la désignation des officiels.
+- Notifier les arbitres et officiels en temps réel.
+
+## Exigences techniques
+
+- Backend en AdonisJS (TypeScript) avec base PostgreSQL.
+- Frontend en Vue 3 et Tailwind CSS.
+- Support de notifications par e-mail ou SMS.
+


### PR DESCRIPTION
## Summary
- add a placeholder `docs/cahier_des_charges.md`
- add `docs/architecture/README.md` folder and overview

## Testing
- `yarn format` *(fails: Couldn't find a script named "format")*
- `yarn --cwd packages/backend format`
- `yarn test` *(fails: Couldn't find a script named "test")*
- `yarn --cwd packages/backend test`

------
https://chatgpt.com/codex/tasks/task_e_68565063767c8329ab46df4f10d40312