### PR TITLE
Add validators for auth endpoints

### DIFF
--- a/packages/backend/app/auth/primary/http/login_controller.ts
+++ b/packages/backend/app/auth/primary/http/login_controller.ts
@@ -2,13 +2,14 @@ import { AuthenticationResult, LoginUserUseCase } from '#auth/use_case/login_use
 import type { HttpContext } from '@adonisjs/core/http'
 import logger from '@adonisjs/core/services/logger'
 import { inject } from '@adonisjs/core'
+import { loginValidator } from '#auth/primary/http/login_validator'
 
 @inject()
 export default class LoginController {
   constructor(private readonly useCase: LoginUserUseCase) {}
 
   async handle({ request, response }: HttpContext) {
-    const { email, password } = request.only(['email', 'password'])
+    const { email, password } = await loginValidator.validate(request.body())
     try {
       const user: AuthenticationResult = await this.useCase.execute(email, password)
       logger.info('User logged in', { user })

--- a/packages/backend/app/auth/primary/http/login_validator.ts
+++ b/packages/backend/app/auth/primary/http/login_validator.ts
@@ -1,0 +1,11 @@
+import vine from '@vinejs/vine'
+import { InferInput } from '@vinejs/vine/types'
+
+export const loginValidator = vine.compile(
+  vine.object({
+    email: vine.string().email(),
+    password: vine.string().minLength(1),
+  })
+)
+
+export type LoginValidatorOutput = InferInput<typeof loginValidator>

--- a/packages/backend/app/auth/primary/http/register_controller.ts
+++ b/packages/backend/app/auth/primary/http/register_controller.ts
@@ -1,13 +1,14 @@
 import { RegisterUserUseCase } from '#auth/use_case/register_user_use_case'
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
+import { registerValidator } from '#auth/primary/http/register_validator'
 
 @inject()
 export default class RegisterController {
   constructor(private registerUserUseCase: RegisterUserUseCase) {}
 
   async handle({ request, response }: HttpContext) {
-    const { email, password } = request.only(['email', 'password'])
+    const { email, password } = await registerValidator.validate(request.body())
     try {
       const user = await this.registerUserUseCase.execute(email, password)
       return response.status(201).json({

--- a/packages/backend/app/auth/primary/http/register_validator.ts
+++ b/packages/backend/app/auth/primary/http/register_validator.ts
@@ -1,0 +1,11 @@
+import vine from '@vinejs/vine'
+import { InferInput } from '@vinejs/vine/types'
+
+export const registerValidator = vine.compile(
+  vine.object({
+    email: vine.string().email(),
+    password: vine.string().minLength(1),
+  })
+)
+
+export type RegisterValidatorOutput = InferInput<typeof registerValidator>

--- a/packages/backend/tests/functional/auth/auth_validation.spec.ts
+++ b/packages/backend/tests/functional/auth/auth_validation.spec.ts
@@ -1,0 +1,48 @@
+import { test } from '@japa/runner'
+import db from '@adonisjs/lucid/services/db'
+import hash from '@adonisjs/core/services/hash'
+import { Role } from '#auth/domain/role'
+
+process.env.JWT_SECRET = 'testsecret'
+process.env.JWT_EXPIRES_IN = '1h'
+
+const createUsersTable = async () => {
+  await db.connection().schema.createTable('users', (table) => {
+    table.uuid('id').primary()
+    table.string('email').notNullable().unique()
+    table.string('password').notNullable()
+    table.text('roles').notNullable()
+  })
+  await db
+    .connection()
+    .table('users')
+    .insert({
+      id: '1',
+      email: 'admin@example.com',
+      password: await hash.make('secret'),
+      roles: JSON.stringify([Role.ADMIN]),
+    })
+}
+
+const dropUsersTable = async () => {
+  await db.connection().schema.dropTable('users')
+  await db.manager.closeAll()
+}
+
+test.group('AuthValidation', (group) => {
+  group.setup(createUsersTable)
+  group.each.teardown(async () => {
+    await db.connection().truncate('users')
+  })
+  group.teardown(dropUsersTable)
+
+  test('rejects invalid login payload', async ({ client }) => {
+    const response = await client.post('/api/auth/login').json({ email: 'bad', password: '' })
+    response.assertStatus(422)
+  })
+
+  test('rejects invalid register payload', async ({ client }) => {
+    const response = await client.post('/api/auth/register').json({ email: 'bad', password: '' })
+    response.assertStatus(422)
+  })
+})


### PR DESCRIPTION
## Summary
- validate login and registration payloads using Vine
- update controllers to use the validators
- test validation behaviour for auth routes

## Testing
- `yarn --cwd packages/backend format`
- `yarn --cwd packages/backend test`

------
https://chatgpt.com/codex/tasks/task_e_6857c446e8b4832993647779a4a81f51