### PR TITLE
Handle expired JWT

### DIFF
--- a/packages/backend/app/auth/secondary/adapters/jwt_token_provider.ts
+++ b/packages/backend/app/auth/secondary/adapters/jwt_token_provider.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken'
 import env from '#start/env'
 import TokenProvider, { TokenPayload } from '#auth/secondary/ports/token_provider'
 import { TokenInvalidError } from '#auth/exceptions/token_invalid_error'
+import { TokenExpiredError } from '#auth/exceptions/token_expired_error'
 
 export class JwtTokenProvider extends TokenProvider {
   private readonly secret: string
@@ -21,6 +22,9 @@ export class JwtTokenProvider extends TokenProvider {
     try {
       return jwt.verify(token, this.secret) as TokenPayload
     } catch (error) {
+      if (error instanceof jwt.TokenExpiredError) {
+        throw new TokenExpiredError()
+      }
       throw new TokenInvalidError()
     }
   }

--- a/packages/backend/tests/unit/auth/secondary/jwt_token_provider.spec.ts
+++ b/packages/backend/tests/unit/auth/secondary/jwt_token_provider.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '@japa/runner'
 import { JwtTokenProvider } from '#auth/secondary/adapters/jwt_token_provider'
+import { TokenExpiredError } from '#auth/exceptions/token_expired_error'
 import env from '#start/env'
 
 process.env.JWT_SECRET = 'testsecret'
@@ -27,6 +28,6 @@ test.group('JwtTokenProvider', () => {
     const token = provider.generate(payload)
     // Wait for token to expire (1s)
     await new Promise((r) => setTimeout(r, 1100))
-    assert.throws(() => provider.verify(token))
+    assert.throws(() => provider.verify(token), TokenExpiredError)
   })
 })


### PR DESCRIPTION
## Summary
- detect expired JWTs in JwtTokenProvider
- test expired JWT scenario

## Testing
- `yarn workspace backend format`
- `yarn workspace backend test`

------
https://chatgpt.com/codex/tasks/task_e_6857c61c856c8329b6b2ef8834a20703