### PR TITLE
Add matches table migration

### DIFF
--- a/packages/backend/database/migrations/0002_create_matches_table.ts
+++ b/packages/backend/database/migrations/0002_create_matches_table.ts
@@ -1,0 +1,26 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'matches'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.uuid('id').primary()
+      table.date('date').notNullable()
+      table.string('heure').notNullable()
+      table.uuid('equipe_domicile_id').notNullable()
+      table.uuid('equipe_exterieur_id').notNullable()
+      // Les officiels peuvent être ajoutés après la création du match
+      table.text('officiels').nullable()
+      table.string('statut').notNullable()
+      table.string('motif_annulation')
+      table.string('motif_report')
+      table.integer('score_domicile')
+      table.integer('score_exterieur')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}


### PR DESCRIPTION
## Summary
- add migration to create matches table in backend
- make the officials field optional

## Testing
- `yarn workspace backend format`
- `yarn workspace backend test`


------
https://chatgpt.com/codex/tasks/task_e_6857c42901f88329936ba962a0e0dd9e