### PR TITLE
Validate UUID for Identifier

### DIFF
--- a/packages/backend/app/shared/domaine/identifier.ts
+++ b/packages/backend/app/shared/domaine/identifier.ts
@@ -1,6 +1,8 @@
 import { ValueObject } from '#shared/domaine/value_object'
 import { randomUUID } from 'node:crypto'
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export class Identifier extends ValueObject<{ value: string }> {
   protected constructor(props: { value: string }) {
     super(props)
@@ -11,6 +13,9 @@ export class Identifier extends ValueObject<{ value: string }> {
   }
 
   static fromString(value: string): Identifier {
+    if (!UUID_REGEX.test(value)) {
+      throw new Error(`Invalid UUID: ${value}`)
+    }
     return new Identifier({ value })
   }
 

--- a/packages/backend/tests/functional/auth/auth_flow.spec.ts
+++ b/packages/backend/tests/functional/auth/auth_flow.spec.ts
@@ -3,6 +3,7 @@ import { test } from '@japa/runner'
 import { UserModel } from '#auth/secondary/infrastructure/models/user'
 import { Role } from '#auth/domain/role'
 import logger from '@adonisjs/core/services/logger'
+import { Identifier } from '#shared/domaine/identifier'
 
 process.env.JWT_SECRET = 'testsecret'
 process.env.JWT_EXPIRES_IN = '1h'
@@ -25,7 +26,12 @@ test.group('AuthFlow', (group) => {
       .send()
     protectedRes.assertOk()
   }).setup(async () => {
-    await UserModel.create({ email: 'admin@example.com', password: 'secret', roles: [Role.ADMIN] })
+    await UserModel.create({
+      id: Identifier.generate().toString(),
+      email: 'admin@example.com',
+      password: 'secret',
+      roles: [Role.ADMIN],
+    })
   })
 
   test('rejects access without token', async ({ client }) => {

--- a/packages/backend/tests/functional/match/lucid_match_repository.spec.ts
+++ b/packages/backend/tests/functional/match/lucid_match_repository.spec.ts
@@ -2,6 +2,7 @@ import { test } from '@japa/runner'
 import { LucidMatchRepository } from '#match/secondary/adapters/lucid_match_repository'
 import { MatchModel } from '#match/secondary/infrastructure/models/match'
 import Match from '#match/domain/match'
+import { Identifier } from '#shared/domaine/identifier'
 import { DateTime } from 'luxon'
 import testUtils from '@adonisjs/core/services/test_utils'
 
@@ -13,7 +14,7 @@ function createMatch(
   date: string,
   heure = '12:00',
   officials: string[] = [official],
-  id = Math.random().toString(36).slice(2)
+  id = Identifier.generate().toString()
 ) {
   return Match.create({
     id,
@@ -104,24 +105,26 @@ test.group('LucidMatchRepository', (group) => {
 
   test('upsert creates or updates a match', async ({ assert }) => {
     const repo = new LucidMatchRepository()
-    const match = createMatch('2025-05-05', '12:00', [official], 'code1')
+    const matchId = Identifier.generate().toString()
+    const match = createMatch('2025-05-05', '12:00', [official], matchId)
     await repo.upsert(match)
 
     let models = await MatchModel.all()
     assert.lengthOf(models, 1)
 
+    const newOfficial = Identifier.generate().toString()
     const updated = Match.create({
       id: match.id.toString(),
       date: match.date,
       heure: match.heure,
       equipeDomicileId: match.equipeDomicileId.toString(),
       equipeExterieurId: match.equipeExterieurId.toString(),
-      officiels: ['new'],
+      officiels: [newOfficial],
     })
     await repo.upsert(updated)
 
     models = await MatchModel.all()
     assert.lengthOf(models, 1)
-    assert.deepEqual(models[0].officiels, ['new'])
+    assert.deepEqual(models[0].officiels, [newOfficial])
   })
 })

--- a/packages/backend/tests/unit/importer/service/upload_csv_service.spec.ts
+++ b/packages/backend/tests/unit/importer/service/upload_csv_service.spec.ts
@@ -6,9 +6,12 @@ import { promises as fs } from 'node:fs'
 import { join } from 'node:path'
 import os from 'node:os'
 import type { MultipartFile } from '@adonisjs/bodyparser'
+import { Identifier } from '#shared/domaine/identifier'
 
-const csvContent =
-  'code renc;le;horaire;club rec;club vis;nom salle\nCODE1;2025-01-01;12:00;A;B;Gym'
+const csvId = Identifier.generate().toString()
+const equipeHome = '11111111-1111-1111-1111-111111111111'
+const equipeAway = '22222222-2222-2222-2222-222222222222'
+const csvContent = `code renc;le;horaire;club rec;club vis;nom salle\n${csvId};2025-01-01;12:00;${equipeHome};${equipeAway};Gym`
 
 /**
  * Tests unitaires pour UploadCsvService

--- a/packages/backend/tests/unit/shared/domaine/identifier.spec.ts
+++ b/packages/backend/tests/unit/shared/domaine/identifier.spec.ts
@@ -1,0 +1,15 @@
+import { test } from '@japa/runner'
+import { Identifier } from '#shared/domaine/identifier'
+
+test.group('Identifier', () => {
+  test('devrait créer un identifiant valide', ({ assert }) => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000'
+    const identifier = Identifier.fromString(uuid)
+
+    assert.equal(identifier.toString(), uuid)
+  })
+
+  test('devrait rejeter un identifiant invalide', ({ assert }) => {
+    assert.throws(() => Identifier.fromString('invalid-uuid'))
+  })
+})


### PR DESCRIPTION
## Summary
- enforce UUID validation when creating Identifier from string
- update functional tests to use valid UUID identifiers
- add dedicated unit tests for Identifier
- adjust importer tests to rely on UUIDs

## Testing
- `yarn format`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685af7efe77c8329ac09535e7d4f2423