### PR TITLE
Add team entity and tests

### DIFF
--- a/packages/backend/app/modules/team/domain/federal_code.ts
+++ b/packages/backend/app/modules/team/domain/federal_code.ts
@@ -1,0 +1,30 @@
+import { ValueObject } from '#shared/domaine/value_object'
+import InvalidTeamException from '#team/exceptions/invalid_team_exception'
+
+export class FederalCode extends ValueObject<{ value: string }> {
+  private static registry = new Set<string>()
+
+  private constructor(props: { value: string }) {
+    const code = props.value?.trim()
+    if (!code) {
+      throw new InvalidTeamException('Le code féd\u00e9ral est requis')
+    }
+    if (FederalCode.registry.has(code)) {
+      throw new InvalidTeamException('Code féd\u00e9ral déjà utilis\u00e9')
+    }
+    super({ value: code })
+    FederalCode.registry.add(code)
+  }
+
+  static fromString(value: string): FederalCode {
+    return new FederalCode({ value })
+  }
+
+  static reset() {
+    FederalCode.registry.clear()
+  }
+
+  toString(): string {
+    return this.props.value
+  }
+}

--- a/packages/backend/app/modules/team/domain/team.ts
+++ b/packages/backend/app/modules/team/domain/team.ts
@@ -1,0 +1,48 @@
+import { Entity } from '#shared/domaine/entity'
+import { Identifier } from '#shared/domaine/identifier'
+import { TeamName } from '#team/domain/team_name'
+import { FederalCode } from '#team/domain/federal_code'
+
+interface Properties {
+  id: Identifier
+  nom: TeamName
+  codeFederal: FederalCode
+  logo?: string
+}
+
+export default class Team extends Entity<Properties> {
+  private constructor(props: Properties) {
+    super(props)
+  }
+
+  static create({
+    id,
+    nom,
+    codeFederal,
+    logo,
+  }: {
+    id?: string
+    nom: string
+    codeFederal: string
+    logo?: string
+  }): Team {
+    return new Team({
+      id: id ? Identifier.fromString(id) : Identifier.generate(),
+      nom: TeamName.fromString(nom),
+      codeFederal: FederalCode.fromString(codeFederal),
+      logo,
+    })
+  }
+
+  get nom() {
+    return this.props.nom
+  }
+
+  get codeFederal() {
+    return this.props.codeFederal
+  }
+
+  get logo() {
+    return this.props.logo
+  }
+}

--- a/packages/backend/app/modules/team/domain/team_name.ts
+++ b/packages/backend/app/modules/team/domain/team_name.ts
@@ -1,0 +1,19 @@
+import { ValueObject } from '#shared/domaine/value_object'
+import InvalidTeamException from '#team/exceptions/invalid_team_exception'
+
+export class TeamName extends ValueObject<{ value: string }> {
+  private constructor(props: { value: string }) {
+    if (!props.value || props.value.trim().length === 0) {
+      throw new InvalidTeamException("Le nom d'équipe est requis")
+    }
+    super({ value: props.value.trim() })
+  }
+
+  static fromString(value: string): TeamName {
+    return new TeamName({ value })
+  }
+
+  toString(): string {
+    return this.props.value
+  }
+}

--- a/packages/backend/app/modules/team/exceptions/invalid_team_exception.ts
+++ b/packages/backend/app/modules/team/exceptions/invalid_team_exception.ts
@@ -1,0 +1,6 @@
+export default class InvalidTeamException extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidTeamException'
+  }
+}

--- a/packages/backend/app/modules/team/index.ts
+++ b/packages/backend/app/modules/team/index.ts
@@ -1,0 +1,1 @@
+export const teamProviderMap: any[] = []

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -34,7 +34,8 @@
     "#shared/*": "./app/shared/*.js",
     "#auth/*": "./app/auth/*.js",
     "#match/*": "./app/modules/match/*.js",
-    "#importer/*": "./app/modules/importer/*.js"
+    "#importer/*": "./app/modules/importer/*.js",
+    "#team/*": "./app/modules/team/*.js"
   },
   "devDependencies": {
     "@adonisjs/assembler": "^7.8.2",

--- a/packages/backend/providers/app_provider.ts
+++ b/packages/backend/providers/app_provider.ts
@@ -2,6 +2,7 @@ import type { ApplicationService } from '@adonisjs/core/types'
 import { authProviderMap } from '#auth/index'
 import { matchProviderMap } from '#match/index'
 import { importerProviderMap } from '#importer/index'
+import { teamProviderMap } from '#team/index'
 
 export default class AppProvider {
   constructor(protected app: ApplicationService) {}
@@ -15,7 +16,7 @@ export default class AppProvider {
    * The container bindings have booted
    */
   async boot() {
-    const sources = [matchProviderMap, authProviderMap, importerProviderMap]
+    const sources = [matchProviderMap, authProviderMap, importerProviderMap, teamProviderMap]
     sources.forEach((map) => {
       map.forEach(([useCase, service]) => {
         this.app.container.bind(useCase, () => {

--- a/packages/backend/tests/unit/team/domain/team.spec.ts
+++ b/packages/backend/tests/unit/team/domain/team.spec.ts
@@ -1,0 +1,31 @@
+import { test } from '@japa/runner'
+import Team from '#team/domain/team'
+import { FederalCode } from '#team/domain/federal_code'
+
+test.group('Team.create', (group) => {
+  group.each.teardown(() => {
+    FederalCode.reset()
+  })
+
+  test('crée une équipe valide', ({ assert }) => {
+    const team = Team.create({ nom: 'HB Club', codeFederal: 'FED1', logo: 'logo.png' })
+
+    assert.equal(team.nom.toString(), 'HB Club')
+    assert.equal(team.codeFederal.toString(), 'FED1')
+    assert.equal(team.logo, 'logo.png')
+  })
+
+  test('rejette un nom vide', ({ assert }) => {
+    assert.throws(() => {
+      Team.create({ nom: '', codeFederal: 'FED2' })
+    }, "Le nom d'équipe est requis")
+  })
+
+  test('rejette un code fédéral déjà utilisé', ({ assert }) => {
+    Team.create({ nom: 'Team A', codeFederal: 'FED3' })
+
+    assert.throws(() => {
+      Team.create({ nom: 'Team B', codeFederal: 'FED3' })
+    }, 'Code fédéral déjà utilisé')
+  })
+})


### PR DESCRIPTION
## Summary
- implement `Team` domain entity with invariants
- create value objects `TeamName` and `FederalCode`
- add team module placeholder and provider registration
- add unit tests validating entity rules
- expose new `#team` path alias

## Testing
- `yarn format`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685af86fed348329a5e87dba7f24f655