### PR TITLE
Add Team repository port and stub

### DIFF
--- a/packages/backend/app/modules/team/secondary/ports/team_repository.ts
+++ b/packages/backend/app/modules/team/secondary/ports/team_repository.ts
@@ -1,0 +1,39 @@
+import Team from '#team/domain/team'
+
+/**
+ * Port d'accès et de manipulation des équipes.
+ */
+export abstract class TeamRepository {
+  /**
+   * Retourne toutes les équipes.
+   */
+  abstract findAll(): Promise<Team[]>
+
+  /**
+   * Recherche une équipe par son identifiant.
+   * @param id Identifiant de l'équipe
+   */
+  abstract findById(id: string): Promise<Team | null>
+
+  /**
+   * Recherche les équipes correspondant au nom donné.
+   * La recherche peut être effectuée en ignorant la casse.
+   * @param name Nom de l'équipe recherché
+   */
+  abstract findByName(name: string): Promise<Team[]>
+
+  /**
+   * Ajoute une nouvelle équipe.
+   */
+  abstract create(team: Team): Promise<void>
+
+  /**
+   * Met à jour une équipe existante.
+   */
+  abstract update(team: Team): Promise<void>
+
+  /**
+   * Supprime une équipe par son identifiant.
+   */
+  abstract delete(id: string): Promise<void>
+}

--- a/packages/backend/tests/unit/team/repository/team_repository.spec.ts
+++ b/packages/backend/tests/unit/team/repository/team_repository.spec.ts
@@ -1,0 +1,56 @@
+import { test } from '@japa/runner'
+import Team from '#team/domain/team'
+import { StubTeamRepository } from '#tests/unit/team/stubs/stub_team_repository'
+import { FederalCode } from '#team/domain/federal_code'
+
+function createTeam(name: string, code: string) {
+  return Team.create({ nom: name, codeFederal: code })
+}
+
+test.group('StubTeamRepository', (group) => {
+  group.each.teardown(() => {
+    FederalCode.reset()
+  })
+  test('create and findAll', async ({ assert }) => {
+    const repo = new StubTeamRepository()
+    const team = createTeam('A', 'CODE1')
+
+    await repo.create(team)
+    const all = await repo.findAll()
+
+    assert.lengthOf(all, 1)
+    assert.equal(all[0].id.toString(), team.id.toString())
+  })
+
+  test('findById returns correct team', async ({ assert }) => {
+    const team = createTeam('A', 'CODE1')
+    const repo = new StubTeamRepository([team])
+
+    const found = await repo.findById(team.id.toString())
+
+    assert.isNotNull(found)
+    assert.equal(found?.id.toString(), team.id.toString())
+  })
+
+  test('update modifies existing team', async ({ assert }) => {
+    const team = createTeam('A', 'CODE1')
+    const repo = new StubTeamRepository([team])
+    const updated = Team.create({ id: team.id.toString(), nom: 'B', codeFederal: 'CODE2' })
+
+    await repo.update(updated)
+    const result = await repo.findByName('B')
+
+    assert.lengthOf(result, 1)
+    assert.equal(result[0].nom.toString(), 'B')
+  })
+
+  test('delete removes a team', async ({ assert }) => {
+    const team = createTeam('A', 'CODE1')
+    const repo = new StubTeamRepository([team])
+
+    await repo.delete(team.id.toString())
+    const all = await repo.findAll()
+
+    assert.lengthOf(all, 0)
+  })
+})

--- a/packages/backend/tests/unit/team/stubs/stub_team_repository.ts
+++ b/packages/backend/tests/unit/team/stubs/stub_team_repository.ts
@@ -1,0 +1,39 @@
+import Team from '#team/domain/team'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+
+export class StubTeamRepository implements TeamRepository {
+  constructor(private teams: Team[] = []) {}
+
+  async findAll(): Promise<Team[]> {
+    return [...this.teams]
+  }
+
+  async findById(id: string): Promise<Team | null> {
+    return this.teams.find((t) => t.id.toString() === id) ?? null
+  }
+
+  async findByName(name: string): Promise<Team[]> {
+    const lower = name.toLowerCase()
+    return this.teams.filter((t) => t.nom.toString().toLowerCase() === lower)
+  }
+
+  async create(team: Team): Promise<void> {
+    this.teams.push(team)
+  }
+
+  async update(team: Team): Promise<void> {
+    const index = this.teams.findIndex((t) => t.id.toString() === team.id.toString())
+    if (index >= 0) {
+      this.teams[index] = team
+    } else {
+      this.teams.push(team)
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    const index = this.teams.findIndex((t) => t.id.toString() === id)
+    if (index >= 0) {
+      this.teams.splice(index, 1)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define `TeamRepository` port with CRUD operations
- provide in-memory `StubTeamRepository` for unit tests
- add behavior tests for the stub repository

## Testing
- `yarn workspace backend format`
- `yarn workspace backend test`

------
https://chatgpt.com/codex/tasks/task_e_685c437b6980832982cbb46f007f74a1