### PR TITLE
Implement team CRUD use cases

### DIFF
--- a/packages/backend/app/modules/team/index.ts
+++ b/packages/backend/app/modules/team/index.ts
@@ -1,1 +1,15 @@
-export const teamProviderMap: any[] = []
+import { CreateTeamUseCase } from '#team/use_case/create_team_use_case'
+import { UpdateTeamUseCase } from '#team/use_case/update_team_use_case'
+import { DeleteTeamUseCase } from '#team/use_case/delete_team_use_case'
+import { ListTeamsUseCase } from '#team/use_case/list_teams_use_case'
+import { CreateTeam } from '#team/service/create_team'
+import { UpdateTeam } from '#team/service/update_team'
+import { DeleteTeam } from '#team/service/delete_team'
+import { ListTeams } from '#team/service/list_teams'
+
+export const teamProviderMap = [
+  [CreateTeamUseCase, CreateTeam],
+  [UpdateTeamUseCase, UpdateTeam],
+  [DeleteTeamUseCase, DeleteTeam],
+  [ListTeamsUseCase, ListTeams],
+]

--- a/packages/backend/app/modules/team/service/create_team.ts
+++ b/packages/backend/app/modules/team/service/create_team.ts
@@ -1,0 +1,22 @@
+import { inject } from '@adonisjs/core'
+import Team from '#team/domain/team'
+import InvalidTeamException from '#team/exceptions/invalid_team_exception'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+import { CreateTeamUseCase } from '#team/use_case/create_team_use_case'
+
+@inject()
+export class CreateTeam extends CreateTeamUseCase {
+  constructor(private readonly repository: TeamRepository) {
+    super()
+  }
+
+  async execute(payload: { nom: string; codeFederal: string; logo?: string }): Promise<Team> {
+    const existing = await this.repository.findByName(payload.nom)
+    if (existing.length > 0) {
+      throw new InvalidTeamException("Nom d'équipe déjà utilisé")
+    }
+    const team = Team.create(payload)
+    await this.repository.create(team)
+    return team
+  }
+}

--- a/packages/backend/app/modules/team/service/delete_team.ts
+++ b/packages/backend/app/modules/team/service/delete_team.ts
@@ -1,0 +1,27 @@
+import { inject } from '@adonisjs/core'
+import InvalidTeamException from '#team/exceptions/invalid_team_exception'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+import { DeleteTeamUseCase } from '#team/use_case/delete_team_use_case'
+import { MatchRepository } from '#match/secondary/ports/match_repository'
+
+@inject()
+export class DeleteTeam extends DeleteTeamUseCase {
+  constructor(
+    private readonly teamRepository: TeamRepository,
+    private readonly matchRepository: MatchRepository
+  ) {
+    super()
+  }
+
+  async execute(id: string): Promise<void> {
+    const team = await this.teamRepository.findById(id)
+    if (!team) {
+      throw new InvalidTeamException('Equipe introuvable')
+    }
+    const matches = await this.matchRepository.findByCriteria({ equipeId: id })
+    if (matches.length > 0) {
+      throw new InvalidTeamException('Equipe associ\u00e9e \u00e0 un match')
+    }
+    await this.teamRepository.delete(id)
+  }
+}

--- a/packages/backend/app/modules/team/service/list_teams.ts
+++ b/packages/backend/app/modules/team/service/list_teams.ts
@@ -1,0 +1,15 @@
+import { inject } from '@adonisjs/core'
+import Team from '#team/domain/team'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+import { ListTeamsUseCase } from '#team/use_case/list_teams_use_case'
+
+@inject()
+export class ListTeams extends ListTeamsUseCase {
+  constructor(private readonly repository: TeamRepository) {
+    super()
+  }
+
+  async execute(): Promise<Team[]> {
+    return this.repository.findAll()
+  }
+}

--- a/packages/backend/app/modules/team/service/update_team.ts
+++ b/packages/backend/app/modules/team/service/update_team.ts
@@ -1,0 +1,29 @@
+import { inject } from '@adonisjs/core'
+import Team from '#team/domain/team'
+import InvalidTeamException from '#team/exceptions/invalid_team_exception'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+import { UpdateTeamUseCase } from '#team/use_case/update_team_use_case'
+
+@inject()
+export class UpdateTeam extends UpdateTeamUseCase {
+  constructor(private readonly repository: TeamRepository) {
+    super()
+  }
+
+  async execute(
+    id: string,
+    payload: { nom: string; codeFederal: string; logo?: string }
+  ): Promise<Team> {
+    const team = await this.repository.findById(id)
+    if (!team) {
+      throw new InvalidTeamException('Equipe introuvable')
+    }
+    const byName = await this.repository.findByName(payload.nom)
+    if (byName.some((t) => t.id.toString() !== id)) {
+      throw new InvalidTeamException("Nom d'équipe déjà utilisé")
+    }
+    const updated = Team.create({ id, ...payload })
+    await this.repository.update(updated)
+    return updated
+  }
+}

--- a/packages/backend/app/modules/team/use_case/create_team_use_case.ts
+++ b/packages/backend/app/modules/team/use_case/create_team_use_case.ts
@@ -1,0 +1,5 @@
+import Team from '#team/domain/team'
+
+export abstract class CreateTeamUseCase {
+  abstract execute(payload: { nom: string; codeFederal: string; logo?: string }): Promise<Team>
+}

--- a/packages/backend/app/modules/team/use_case/delete_team_use_case.ts
+++ b/packages/backend/app/modules/team/use_case/delete_team_use_case.ts
@@ -1,0 +1,3 @@
+export abstract class DeleteTeamUseCase {
+  abstract execute(id: string): Promise<void>
+}

--- a/packages/backend/app/modules/team/use_case/list_teams_use_case.ts
+++ b/packages/backend/app/modules/team/use_case/list_teams_use_case.ts
@@ -1,0 +1,5 @@
+import Team from '#team/domain/team'
+
+export abstract class ListTeamsUseCase {
+  abstract execute(): Promise<Team[]>
+}

--- a/packages/backend/app/modules/team/use_case/update_team_use_case.ts
+++ b/packages/backend/app/modules/team/use_case/update_team_use_case.ts
@@ -1,0 +1,8 @@
+import Team from '#team/domain/team'
+
+export abstract class UpdateTeamUseCase {
+  abstract execute(
+    id: string,
+    payload: { nom: string; codeFederal: string; logo?: string }
+  ): Promise<Team>
+}

--- a/packages/backend/tests/unit/team/use_case/team_crud.spec.ts
+++ b/packages/backend/tests/unit/team/use_case/team_crud.spec.ts
@@ -1,0 +1,109 @@
+import { test } from '@japa/runner'
+import { StubTeamRepository } from '#tests/unit/team/stubs/stub_team_repository'
+import { StubMatchRepository } from '#tests/unit/match/stubs/stub_match_repository'
+import { CreateTeam } from '#team/service/create_team'
+import { UpdateTeam } from '#team/service/update_team'
+import { DeleteTeam } from '#team/service/delete_team'
+import { ListTeams } from '#team/service/list_teams'
+import Team from '#team/domain/team'
+import { FederalCode } from '#team/domain/federal_code'
+import InvalidTeamException from '#team/exceptions/invalid_team_exception'
+import Match from '#match/domain/match'
+
+const equipeId = '11111111-1111-1111-1111-111111111111'
+const otherId = '22222222-2222-2222-2222-222222222222'
+
+function createTeam(name: string, code: string, id?: string) {
+  return Team.create({ id, nom: name, codeFederal: code })
+}
+
+test.group('Team use cases', (group) => {
+  group.each.teardown(() => {
+    FederalCode.reset()
+  })
+
+  test('create team rejects duplicate name', async ({ assert }) => {
+    const repo = new StubTeamRepository([createTeam('A', 'C1')])
+    const useCase = new CreateTeam(repo)
+
+    await assert.rejects(
+      () => useCase.execute({ nom: 'A', codeFederal: 'C2' }),
+      InvalidTeamException
+    )
+  })
+
+  test('create team stores and returns entity', async ({ assert }) => {
+    const repo = new StubTeamRepository()
+    const useCase = new CreateTeam(repo)
+
+    const team = await useCase.execute({ nom: 'A', codeFederal: 'C1' })
+
+    assert.equal(team.nom.toString(), 'A')
+    const all = await repo.findAll()
+    assert.lengthOf(all, 1)
+  })
+
+  test('update team changes name', async ({ assert }) => {
+    const team = createTeam('A', 'C1', equipeId)
+    const repo = new StubTeamRepository([team])
+    const useCase = new UpdateTeam(repo)
+
+    const updated = await useCase.execute(equipeId, { nom: 'B', codeFederal: 'C1' })
+
+    assert.equal(updated.nom.toString(), 'B')
+    const saved = await repo.findById(equipeId)
+    assert.equal(saved?.nom.toString(), 'B')
+  })
+
+  test('update team rejects duplicate name', async ({ assert }) => {
+    const teamA = createTeam('A', 'C1', equipeId)
+    const teamB = createTeam('B', 'C2', otherId)
+    const repo = new StubTeamRepository([teamA, teamB])
+    const useCase = new UpdateTeam(repo)
+
+    await assert.rejects(
+      () => useCase.execute(otherId, { nom: 'A', codeFederal: 'C2' }),
+      InvalidTeamException
+    )
+  })
+
+  test('delete team prevents removal when match exists', async ({ assert }) => {
+    const team = createTeam('A', 'C1', equipeId)
+    const repo = new StubTeamRepository([team])
+    const match = Match.create({
+      date: new Date('2025-01-01'),
+      heure: '12:00',
+      equipeDomicileId: equipeId,
+      equipeExterieurId: otherId,
+      officiels: [],
+      codeRenc: '1',
+    })
+    const matchRepo = new StubMatchRepository([match])
+    const useCase = new DeleteTeam(repo, matchRepo)
+
+    await assert.rejects(() => useCase.execute(equipeId), InvalidTeamException)
+  })
+
+  test('delete team removes entity', async ({ assert }) => {
+    const team = createTeam('A', 'C1', equipeId)
+    const repo = new StubTeamRepository([team])
+    const matchRepo = new StubMatchRepository([])
+    const useCase = new DeleteTeam(repo, matchRepo)
+
+    await useCase.execute(equipeId)
+
+    const all = await repo.findAll()
+    assert.lengthOf(all, 0)
+  })
+
+  test('list teams returns all', async ({ assert }) => {
+    const teamA = createTeam('A', 'C1')
+    const teamB = createTeam('B', 'C2')
+    const repo = new StubTeamRepository([teamA, teamB])
+    const useCase = new ListTeams(repo)
+
+    const list = await useCase.execute()
+
+    assert.lengthOf(list, 2)
+  })
+})


### PR DESCRIPTION
## Summary
- add use cases for team CRUD
- implement CreateTeam/UpdateTeam/DeleteTeam/ListTeams services
- expose services via provider map
- test team use cases with repository stubs

## Testing
- `yarn format`
- `yarn lint`
- `yarn test` *(fails: 60 passed, 46 failed)*
- baseline `yarn test` before changes *(55 passed, 44 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c5867ea508329bad74a6f6c42659c