### PR TITLE
Add details in CSV import report

### DIFF
--- a/docs/Api/HBManager API/Import CSV in background.bru
+++ b/docs/Api/HBManager API/Import CSV in background.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Import CSV in background
+  type: http
+  seq: 1
+}
+
+post {
+  url: http://localhost:3333/api/import/csv
+  body: multipartForm
+  auth: none
+}
+
+body:multipart-form {
+  file: @file(/Users/elie/Dev/hand/HBManager/packages/backend/tmp/2024-04-07_Export_GH-competition.csv)
+}

--- a/docs/Api/HBManager API/bruno.json
+++ b/docs/Api/HBManager API/bruno.json
@@ -1,0 +1,13 @@
+{
+  "version": "1",
+  "name": "HBManager API",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ],
+  "presets": {
+    "requestType": "http",
+    "requestUrl": "http://localhost"
+  }
+}

--- a/docs/api_openapi.yaml
+++ b/docs/api_openapi.yaml
@@ -174,6 +174,10 @@ paths:
                         type: integer
                       importedCount:
                         type: integer
+                      addedCount:
+                        type: integer
+                      updatedCount:
+                        type: integer
                       ignored:
                         type: array
                         items:

--- a/packages/backend/app/modules/importer/domain/import_report.ts
+++ b/packages/backend/app/modules/importer/domain/import_report.ts
@@ -7,5 +7,7 @@ export interface IgnoredLine {
 export interface CsvImportReport {
   totalLines: number
   importedCount: number
+  addedCount: number
+  updatedCount: number
   ignored: IgnoredLine[]
 }

--- a/packages/backend/app/modules/importer/service/upload_csv_service.ts
+++ b/packages/backend/app/modules/importer/service/upload_csv_service.ts
@@ -65,12 +65,6 @@ export class UploadCsvService extends UploadCsvUseCase {
         throw new Error('Encodage invalide : UTF-8 requis')
       }
 
-<<<<<<< codex/ajouter-statistiques-sur-l-upload-de-csv
-      const existingMatches = await this.matchRepository.findAll()
-      const existingCodes = new Set(existingMatches.map((m) => m.codeRenc))
-
-      const records = parse(buffer.toString('utf8'), {
-=======
       const content = buffer.toString('utf8')
 
       const [headerLine] = content.split(/\r?\n/)
@@ -80,9 +74,10 @@ export class UploadCsvService extends UploadCsvUseCase {
       if (missing.length > 0) {
         throw new Error('Entêtes manquants')
       }
+      const existingMatches = await this.matchRepository.findAll()
+      const existingCodes = new Set(existingMatches.map((m) => m.codeRenc))
 
       const records = parse(content, {
->>>>>>> main
         columns: true,
         skip_empty_lines: true,
         delimiter: ';',

--- a/packages/backend/tests/functional/importer/upload_csv_controller.spec.ts
+++ b/packages/backend/tests/functional/importer/upload_csv_controller.spec.ts
@@ -32,6 +32,8 @@ test.group('UploadCsvController', (group) => {
     // assert.include(report, ['totalLines', 'importedCount', 'ignored'])
     assert.equal(report.totalLines, 1)
     assert.equal(report.importedCount, 1)
+    assert.equal(report.addedCount, 1)
+    assert.equal(report.updatedCount, 0)
   })
 
   test('rejects file larger than 5MB', async ({ client }) => {
@@ -93,6 +95,10 @@ test.group('UploadCsvController', (group) => {
     response.assertStatus(201)
     const matches = await MatchModel.all()
     assert.lengthOf(matches, 1)
+    const report = response.body().report
+    assert.equal(report.importedCount, 1)
+    assert.equal(report.addedCount, 0)
+    assert.equal(report.updatedCount, 1)
   })
 
   test('reports invalid line', async ({ client, assert }) => {
@@ -111,6 +117,8 @@ test.group('UploadCsvController', (group) => {
     const report = response.body().report
     assert.equal(report.totalLines, 2)
     assert.equal(report.importedCount, 1)
+    assert.equal(report.addedCount, 1)
+    assert.equal(report.updatedCount, 0)
     assert.lengthOf(report.ignored, 1)
     assert.equal(report.ignored[0].lineNumber, 3)
 


### PR DESCRIPTION
## Summary
- add addedCount and updatedCount in import report
- track created vs updated matches when uploading CSV
- document new fields in OpenAPI spec
- test counts in CSV upload controller
- check updates using `codeRenc`

## Testing
- `yarn workspace backend format`
- `yarn workspace backend test` *(fails: InvalidMatchException: Date du match invalide)*

------
https://chatgpt.com/codex/tasks/task_e_685c5738be108329ad2ad5be460b7072