### PR TITLE
Ajout des routes CRUD équipe

### DIFF
--- a/packages/backend/app/modules/team/index.ts
+++ b/packages/backend/app/modules/team/index.ts
@@ -6,10 +6,13 @@ import { CreateTeam } from '#team/service/create_team'
 import { UpdateTeam } from '#team/service/update_team'
 import { DeleteTeam } from '#team/service/delete_team'
 import { ListTeams } from '#team/service/list_teams'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+import { LucidTeamRepository } from '#team/secondary/adapters/lucid_team_repository'
 
 export const teamProviderMap = [
   [CreateTeamUseCase, CreateTeam],
   [UpdateTeamUseCase, UpdateTeam],
   [DeleteTeamUseCase, DeleteTeam],
   [ListTeamsUseCase, ListTeams],
+  [TeamRepository, LucidTeamRepository],
 ]

--- a/packages/backend/app/modules/team/primary/http/create_team_controller.ts
+++ b/packages/backend/app/modules/team/primary/http/create_team_controller.ts
@@ -1,0 +1,28 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { CreateTeamUseCase } from '#team/use_case/create_team_use_case'
+import { upsertTeamValidator } from '#team/primary/http/upsert_team_validator'
+import InvalidTeamException from '#team/exceptions/invalid_team_exception'
+
+@inject()
+export default class CreateTeamController {
+  constructor(private readonly useCase: CreateTeamUseCase) {}
+
+  async handle({ request, response }: HttpContext) {
+    const payload = await upsertTeamValidator.validate(request.body())
+    try {
+      const team = await this.useCase.execute(payload)
+      return response.created({
+        id: team.id.toString(),
+        nom: team.nom.toString(),
+        codeFederal: team.codeFederal.toString(),
+        logo: team.logo ?? null,
+      })
+    } catch (error) {
+      if (error instanceof InvalidTeamException) {
+        return response.badRequest({ error: error.message })
+      }
+      throw error
+    }
+  }
+}

--- a/packages/backend/app/modules/team/primary/http/delete_team_controller.ts
+++ b/packages/backend/app/modules/team/primary/http/delete_team_controller.ts
@@ -1,0 +1,21 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { DeleteTeamUseCase } from '#team/use_case/delete_team_use_case'
+import InvalidTeamException from '#team/exceptions/invalid_team_exception'
+
+@inject()
+export default class DeleteTeamController {
+  constructor(private readonly useCase: DeleteTeamUseCase) {}
+
+  async handle({ params, response }: HttpContext) {
+    try {
+      await this.useCase.execute(params.id)
+      return response.noContent()
+    } catch (error) {
+      if (error instanceof InvalidTeamException) {
+        return response.badRequest({ error: error.message })
+      }
+      throw error
+    }
+  }
+}

--- a/packages/backend/app/modules/team/primary/http/get_teams_controller.ts
+++ b/packages/backend/app/modules/team/primary/http/get_teams_controller.ts
@@ -1,0 +1,21 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { ListTeamsUseCase } from '#team/use_case/list_teams_use_case'
+
+@inject()
+export default class GetTeamsController {
+  constructor(private readonly useCase: ListTeamsUseCase) {}
+
+  async handle({ response }: HttpContext) {
+    const teams = await this.useCase.execute()
+
+    const body = teams.map((t) => ({
+      id: t.id.toString(),
+      nom: t.nom.toString(),
+      codeFederal: t.codeFederal.toString(),
+      logo: t.logo ?? null,
+    }))
+
+    return response.ok(body)
+  }
+}

--- a/packages/backend/app/modules/team/primary/http/update_team_controller.ts
+++ b/packages/backend/app/modules/team/primary/http/update_team_controller.ts
@@ -1,0 +1,28 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { UpdateTeamUseCase } from '#team/use_case/update_team_use_case'
+import { upsertTeamValidator } from '#team/primary/http/upsert_team_validator'
+import InvalidTeamException from '#team/exceptions/invalid_team_exception'
+
+@inject()
+export default class UpdateTeamController {
+  constructor(private readonly useCase: UpdateTeamUseCase) {}
+
+  async handle({ request, response, params }: HttpContext) {
+    const payload = await upsertTeamValidator.validate(request.body())
+    try {
+      const team = await this.useCase.execute(params.id, payload)
+      return response.ok({
+        id: team.id.toString(),
+        nom: team.nom.toString(),
+        codeFederal: team.codeFederal.toString(),
+        logo: team.logo ?? null,
+      })
+    } catch (error) {
+      if (error instanceof InvalidTeamException) {
+        return response.badRequest({ error: error.message })
+      }
+      throw error
+    }
+  }
+}

--- a/packages/backend/app/modules/team/primary/http/upsert_team_validator.ts
+++ b/packages/backend/app/modules/team/primary/http/upsert_team_validator.ts
@@ -1,0 +1,12 @@
+import vine from '@vinejs/vine'
+import { InferInput } from '@vinejs/vine/types'
+
+export const upsertTeamValidator = vine.compile(
+  vine.object({
+    nom: vine.string().trim(),
+    codeFederal: vine.string().trim(),
+    logo: vine.string().optional(),
+  })
+)
+
+export type UpsertTeamValidatorOutput = InferInput<typeof upsertTeamValidator>

--- a/packages/backend/app/modules/team/secondary/adapters/lucid_team_repository.ts
+++ b/packages/backend/app/modules/team/secondary/adapters/lucid_team_repository.ts
@@ -1,0 +1,96 @@
+import Team from '#team/domain/team'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+import { TeamModel } from '#team/secondary/infrastructure/models/team'
+import { DatabaseConnectionException } from '#exceptions/database_connection_exception'
+
+export class LucidTeamRepository implements TeamRepository {
+  private toDomain(model: TeamModel): Team {
+    return Team.create({
+      id: model.id,
+      nom: model.nom,
+      codeFederal: model.codeFederal,
+      logo: model.logo ?? undefined,
+    })
+  }
+
+  async findAll(): Promise<Team[]> {
+    try {
+      const models = await TeamModel.all()
+      return models.map((m) => this.toDomain(m))
+    } catch (error) {
+      if (error && ['ECONNREFUSED', 'ENOTFOUND'].includes((error as any).code)) {
+        throw new DatabaseConnectionException()
+      }
+      throw error
+    }
+  }
+
+  async findById(id: string): Promise<Team | null> {
+    try {
+      const model = await TeamModel.find(id)
+      return model ? this.toDomain(model) : null
+    } catch (error) {
+      if (error && ['ECONNREFUSED', 'ENOTFOUND'].includes((error as any).code)) {
+        throw new DatabaseConnectionException()
+      }
+      throw error
+    }
+  }
+
+  async findByName(name: string): Promise<Team[]> {
+    try {
+      const models = await TeamModel.query().whereRaw('LOWER(nom) = ?', [name.toLowerCase()])
+      return models.map((m) => this.toDomain(m))
+    } catch (error) {
+      if (error && ['ECONNREFUSED', 'ENOTFOUND'].includes((error as any).code)) {
+        throw new DatabaseConnectionException()
+      }
+      throw error
+    }
+  }
+
+  async create(team: Team): Promise<void> {
+    try {
+      await TeamModel.create({
+        id: team.id.toString(),
+        nom: team.nom.toString(),
+        codeFederal: team.codeFederal.toString(),
+        logo: team.logo ?? null,
+      })
+    } catch (error) {
+      if (error && ['ECONNREFUSED', 'ENOTFOUND'].includes((error as any).code)) {
+        throw new DatabaseConnectionException()
+      }
+      throw error
+    }
+  }
+
+  async update(team: Team): Promise<void> {
+    const trx = await TeamModel.transaction()
+    try {
+      const model = await TeamModel.findOrFail(team.id.toString(), { client: trx })
+      model.nom = team.nom.toString()
+      model.codeFederal = team.codeFederal.toString()
+      model.logo = team.logo ?? null
+      await model.save()
+      await trx.commit()
+    } catch (error) {
+      await trx.rollback()
+      if (error && ['ECONNREFUSED', 'ENOTFOUND'].includes((error as any).code)) {
+        throw new DatabaseConnectionException()
+      }
+      throw error
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await TeamModel.query().where('id', id).delete()
+    } catch (error) {
+      if (error && ['ECONNREFUSED', 'ENOTFOUND'].includes((error as any).code)) {
+        throw new DatabaseConnectionException()
+      }
+      throw error
+    }
+  }
+}

--- a/packages/backend/app/modules/team/secondary/infrastructure/models/team.ts
+++ b/packages/backend/app/modules/team/secondary/infrastructure/models/team.ts
@@ -1,0 +1,24 @@
+import { BaseModel, column, dateTimeColumn } from '@adonisjs/lucid/orm'
+import { DateTime } from 'luxon'
+
+export class TeamModel extends BaseModel {
+  static table = 'teams'
+
+  @column({ isPrimary: true })
+  declare id: string
+
+  @column()
+  declare nom: string
+
+  @column({ columnName: 'code_federal' })
+  declare codeFederal: string
+
+  @column()
+  declare logo?: string | null
+
+  @dateTimeColumn({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @dateTimeColumn({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/packages/backend/database/migrations/0003_create_teams_table.ts
+++ b/packages/backend/database/migrations/0003_create_teams_table.ts
@@ -1,0 +1,20 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'teams'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.uuid('id').primary()
+      table.string('nom').notNullable().unique()
+      table.string('code_federal').notNullable().unique()
+      table.string('logo')
+      table.date('created_at').notNullable()
+      table.date('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/packages/backend/start/routes.ts
+++ b/packages/backend/start/routes.ts
@@ -15,6 +15,10 @@ const loginController = () => import('#auth/primary/http/login_controller')
 const registerController = () => import('#auth/primary/http/register_controller')
 const getMatchesController = () => import('#match/primary/http/get_matches_controller')
 const uploadCsvController = () => import('#importer/primary/http/upload_csv_controller')
+const getTeamsController = () => import('#team/primary/http/get_teams_controller')
+const createTeamController = () => import('#team/primary/http/create_team_controller')
+const updateTeamController = () => import('#team/primary/http/update_team_controller')
+const deleteTeamController = () => import('#team/primary/http/delete_team_controller')
 
 router.post('/api/auth/register', [registerController])
 
@@ -35,3 +39,8 @@ router
 router.get('/api/matches', [getMatchesController])
 
 router.post('/api/import/csv', [uploadCsvController])
+
+router.get('/api/equipes', [getTeamsController])
+router.post('/api/equipes', [createTeamController])
+router.put('/api/equipes/:id', [updateTeamController])
+router.delete('/api/equipes/:id', [deleteTeamController])

--- a/packages/backend/tests/functional/team/create_team_controller.spec.ts
+++ b/packages/backend/tests/functional/team/create_team_controller.spec.ts
@@ -1,0 +1,20 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { TeamModel } from '#team/secondary/infrastructure/models/team'
+import { FederalCode } from '#team/domain/federal_code'
+
+test.group('CreateTeamController', (group) => {
+  group.each.setup(async () => {
+    await testUtils.db().truncate()
+    FederalCode.reset()
+  })
+
+  test('creates a team', async ({ client, assert }) => {
+    const response = await client.post('/api/equipes').json({ nom: 'A', codeFederal: 'C1' }).send()
+
+    response.assertStatus(201)
+    const teams = await TeamModel.all()
+    assert.lengthOf(teams, 1)
+    assert.equal(teams[0].nom, 'A')
+  })
+})

--- a/packages/backend/tests/functional/team/delete_team_controller.spec.ts
+++ b/packages/backend/tests/functional/team/delete_team_controller.spec.ts
@@ -1,0 +1,35 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import Team from '#team/domain/team'
+import { TeamModel } from '#team/secondary/infrastructure/models/team'
+import { FederalCode } from '#team/domain/federal_code'
+import { Identifier } from '#shared/domaine/identifier'
+
+function createTeam(
+  nom: string = Identifier.generate().toString(),
+  code: string = Identifier.generate().toString()
+) {
+  return Team.create({ nom, codeFederal: code })
+}
+
+test.group('DeleteTeamController', (group) => {
+  group.each.setup(async () => {
+    await testUtils.db().truncate()
+    FederalCode.reset()
+  })
+
+  test('deletes a team', async ({ client, assert }) => {
+    const team = createTeam()
+    await TeamModel.create({
+      id: team.id.toString(),
+      nom: team.nom.toString(),
+      codeFederal: team.codeFederal.toString(),
+    })
+    FederalCode.reset()
+
+    const response = await client.delete(`/api/equipes/${team.id}`).send()
+    response.assertStatus(204)
+    const teams = await TeamModel.all()
+    assert.lengthOf(teams, 0)
+  })
+})

--- a/packages/backend/tests/functional/team/get_teams_controller.spec.ts
+++ b/packages/backend/tests/functional/team/get_teams_controller.spec.ts
@@ -1,0 +1,40 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import Team from '#team/domain/team'
+import { TeamModel } from '#team/secondary/infrastructure/models/team'
+import { FederalCode } from '#team/domain/federal_code'
+import { Identifier } from '#shared/domaine/identifier'
+
+function createTeam(
+  nom: string = Identifier.generate().toString(),
+  code: string = Identifier.generate().toString()
+) {
+  return Team.create({ nom, codeFederal: code })
+}
+
+test.group('GetTeamsController', (group) => {
+  group.each.setup(async () => {
+    await testUtils.db().truncate()
+    FederalCode.reset()
+  })
+
+  test('returns all teams', async ({ client, assert }) => {
+    const teamA = createTeam()
+    const teamB = createTeam()
+    await TeamModel.create({
+      id: teamA.id.toString(),
+      nom: teamA.nom.toString(),
+      codeFederal: teamA.codeFederal.toString(),
+    })
+    await TeamModel.create({
+      id: teamB.id.toString(),
+      nom: teamB.nom.toString(),
+      codeFederal: teamB.codeFederal.toString(),
+    })
+    FederalCode.reset()
+
+    const response = await client.get('/api/equipes').send()
+    response.assertStatus(200)
+    assert.lengthOf(response.body(), 2)
+  })
+})

--- a/packages/backend/tests/functional/team/update_team_controller.spec.ts
+++ b/packages/backend/tests/functional/team/update_team_controller.spec.ts
@@ -1,0 +1,39 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import Team from '#team/domain/team'
+import { TeamModel } from '#team/secondary/infrastructure/models/team'
+import { FederalCode } from '#team/domain/federal_code'
+import { Identifier } from '#shared/domaine/identifier'
+
+function createTeam(
+  nom: string = Identifier.generate().toString(),
+  code: string = Identifier.generate().toString()
+) {
+  return Team.create({ nom, codeFederal: code })
+}
+
+test.group('UpdateTeamController', (group) => {
+  group.each.setup(async () => {
+    await testUtils.db().truncate()
+    FederalCode.reset()
+  })
+
+  test('updates a team', async ({ client, assert }) => {
+    const team = createTeam()
+    await TeamModel.create({
+      id: team.id.toString(),
+      nom: team.nom.toString(),
+      codeFederal: team.codeFederal.toString(),
+    })
+    FederalCode.reset()
+
+    const response = await client
+      .put(`/api/equipes/${team.id}`)
+      .json({ nom: 'B', codeFederal: team.codeFederal.toString() })
+      .send()
+
+    response.assertStatus(200)
+    const updated = await TeamModel.find(team.id.toString())
+    assert.equal(updated?.nom, 'B')
+  })
+})


### PR DESCRIPTION
## Summary
- ajouter migration `teams`
- implémenter `LucidTeamRepository`
- créer les contrôleurs HTTP pour l'entité équipe
- exposer les routes REST `/api/equipes`
- ajouter les tests d'intégration

## Testing
- `yarn format`
- `yarn test` *(échoue)*

------
https://chatgpt.com/codex/tasks/task_e_685ce533a9f08329b37acdf56217eee3