### PR TITLE
feat: match details endpoint

### DIFF
--- a/docs/api_openapi.yaml
+++ b/docs/api_openapi.yaml
@@ -142,6 +142,60 @@ paths:
                         type: string
                     statut:
                       type: string
+  /api/matches/{id}:
+    get:
+      summary: Get match details
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Match details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  date:
+                    type: string
+                    format: date-time
+                  heure:
+                    type: string
+                  statut:
+                    type: string
+                  codeRenc:
+                    type: string
+                  officiels:
+                    type: array
+                    items:
+                      type: string
+                  equipeDomicile:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      nom:
+                        type: string
+                      codeFederal:
+                        type: string
+                      logo:
+                        type: string
+                  equipeExterieur:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      nom:
+                        type: string
+                      codeFederal:
+                        type: string
+                      logo:
+                        type: string
   /api/import/csv:
     post:
       summary: Import matches from CSV

--- a/packages/backend/app/modules/match/index.ts
+++ b/packages/backend/app/modules/match/index.ts
@@ -1,9 +1,12 @@
 import { GetMatchesUseCase } from '#match/use_case/get_matches_use_case'
+import { GetMatchUseCase } from '#match/use_case/get_match_use_case'
 import { GetMatches } from '#match/service/get_matches'
+import { GetMatch } from '#match/service/get_match'
 import { MatchRepository } from '#match/secondary/ports/match_repository'
 import { LucidMatchRepository } from '#match/secondary/adapters/lucid_match_repository'
 
 export const matchProviderMap = [
   [GetMatchesUseCase, GetMatches],
+  [GetMatchUseCase, GetMatch],
   [MatchRepository, LucidMatchRepository],
 ]

--- a/packages/backend/app/modules/match/primary/http/get_match_controller.ts
+++ b/packages/backend/app/modules/match/primary/http/get_match_controller.ts
@@ -1,0 +1,34 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { GetMatchUseCase } from '#match/use_case/get_match_use_case'
+
+@inject()
+export default class GetMatchController {
+  constructor(private readonly useCase: GetMatchUseCase) {}
+
+  async handle({ params, response }: HttpContext) {
+    const result = await this.useCase.execute(params.id)
+    const { match, equipeDomicile, equipeExterieur } = result
+
+    return response.ok({
+      id: match.id.toString(),
+      date: match.date.toISO(),
+      heure: match.heure,
+      statut: match.statut,
+      codeRenc: match.codeRenc,
+      officiels: match.officiels.map((o) => o.toString()),
+      equipeDomicile: {
+        id: equipeDomicile.id.toString(),
+        nom: equipeDomicile.nom.toString(),
+        codeFederal: equipeDomicile.codeFederal.toString(),
+        logo: equipeDomicile.logo ?? null,
+      },
+      equipeExterieur: {
+        id: equipeExterieur.id.toString(),
+        nom: equipeExterieur.nom.toString(),
+        codeFederal: equipeExterieur.codeFederal.toString(),
+        logo: equipeExterieur.logo ?? null,
+      },
+    })
+  }
+}

--- a/packages/backend/app/modules/match/secondary/adapters/lucid_match_repository.ts
+++ b/packages/backend/app/modules/match/secondary/adapters/lucid_match_repository.ts
@@ -59,6 +59,18 @@ export class LucidMatchRepository implements MatchRepository {
     }
   }
 
+  async findById(id: string): Promise<Match | null> {
+    try {
+      const model = await MatchModel.find(id)
+      return model ? this.toDomain(model) : null
+    } catch (error) {
+      if (error && ['ECONNREFUSED', 'ENOTFOUND'].includes((error as any).code)) {
+        throw new DatabaseConnectionException()
+      }
+      throw error
+    }
+  }
+
   async upsert(match: Match): Promise<void> {
     try {
       const existing = await MatchModel.query().where('code_renc', match.codeRenc).first()

--- a/packages/backend/app/modules/match/secondary/ports/match_repository.ts
+++ b/packages/backend/app/modules/match/secondary/ports/match_repository.ts
@@ -35,6 +35,12 @@ export abstract class MatchRepository {
   abstract findByCriteria(criteria: MatchSearchCriteria): Promise<Match[]>
 
   /**
+   * Recherche un match par son identifiant.
+   * @param id Identifiant du match
+   */
+  abstract findById(id: string): Promise<Match | null>
+
+  /**
    * Crée ou met à jour un match en base selon son identifiant naturel.
    * @param match Match à sauvegarder
    */

--- a/packages/backend/app/modules/match/service/get_match.ts
+++ b/packages/backend/app/modules/match/service/get_match.ts
@@ -1,0 +1,28 @@
+import { inject } from '@adonisjs/core'
+import InvalidMatchException from '#match/exceptions/invalid_match_exception'
+import { MatchRepository } from '#match/secondary/ports/match_repository'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+import { GetMatchUseCase, MatchDetails } from '#match/use_case/get_match_use_case'
+
+@inject()
+export class GetMatch extends GetMatchUseCase {
+  constructor(
+    private readonly matchRepository: MatchRepository,
+    private readonly teamRepository: TeamRepository
+  ) {
+    super()
+  }
+
+  async execute(id: string): Promise<MatchDetails> {
+    const match = await this.matchRepository.findById(id)
+    if (!match) {
+      throw new InvalidMatchException('Match introuvable')
+    }
+    const home = await this.teamRepository.findById(match.equipeDomicileId.toString())
+    const away = await this.teamRepository.findById(match.equipeExterieurId.toString())
+    if (!home || !away) {
+      throw new InvalidMatchException('Equipe introuvable')
+    }
+    return { match, equipeDomicile: home, equipeExterieur: away }
+  }
+}

--- a/packages/backend/app/modules/match/use_case/get_match_use_case.ts
+++ b/packages/backend/app/modules/match/use_case/get_match_use_case.ts
@@ -1,0 +1,12 @@
+import Match from '#match/domain/match'
+import Team from '#team/domain/team'
+
+export interface MatchDetails {
+  match: Match
+  equipeDomicile: Team
+  equipeExterieur: Team
+}
+
+export abstract class GetMatchUseCase {
+  abstract execute(id: string): Promise<MatchDetails>
+}

--- a/packages/backend/app/modules/team/index.ts
+++ b/packages/backend/app/modules/team/index.ts
@@ -6,10 +6,13 @@ import { CreateTeam } from '#team/service/create_team'
 import { UpdateTeam } from '#team/service/update_team'
 import { DeleteTeam } from '#team/service/delete_team'
 import { ListTeams } from '#team/service/list_teams'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+import { MemoryTeamRepository } from '#team/secondary/adapters/memory_team_repository'
 
 export const teamProviderMap = [
   [CreateTeamUseCase, CreateTeam],
   [UpdateTeamUseCase, UpdateTeam],
   [DeleteTeamUseCase, DeleteTeam],
   [ListTeamsUseCase, ListTeams],
+  [TeamRepository, MemoryTeamRepository],
 ]

--- a/packages/backend/app/modules/team/secondary/adapters/memory_team_repository.ts
+++ b/packages/backend/app/modules/team/secondary/adapters/memory_team_repository.ts
@@ -1,0 +1,39 @@
+import Team from '#team/domain/team'
+import { TeamRepository } from '#team/secondary/ports/team_repository'
+
+export class MemoryTeamRepository implements TeamRepository {
+  constructor(private teams: Team[] = []) {}
+
+  async findAll(): Promise<Team[]> {
+    return [...this.teams]
+  }
+
+  async findById(id: string): Promise<Team | null> {
+    return this.teams.find((t) => t.id.toString() === id) ?? null
+  }
+
+  async findByName(name: string): Promise<Team[]> {
+    const lower = name.toLowerCase()
+    return this.teams.filter((t) => t.nom.toString().toLowerCase() === lower)
+  }
+
+  async create(team: Team): Promise<void> {
+    this.teams.push(team)
+  }
+
+  async update(team: Team): Promise<void> {
+    const index = this.teams.findIndex((t) => t.id.toString() === team.id.toString())
+    if (index >= 0) {
+      this.teams[index] = team
+    } else {
+      this.teams.push(team)
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    const index = this.teams.findIndex((t) => t.id.toString() === id)
+    if (index >= 0) {
+      this.teams.splice(index, 1)
+    }
+  }
+}

--- a/packages/backend/start/routes.ts
+++ b/packages/backend/start/routes.ts
@@ -14,6 +14,7 @@ import { middleware } from '#start/kernel'
 const loginController = () => import('#auth/primary/http/login_controller')
 const registerController = () => import('#auth/primary/http/register_controller')
 const getMatchesController = () => import('#match/primary/http/get_matches_controller')
+const getMatchController = () => import('#match/primary/http/get_match_controller')
 const uploadCsvController = () => import('#importer/primary/http/upload_csv_controller')
 
 router.post('/api/auth/register', [registerController])
@@ -33,5 +34,6 @@ router
   .use(middleware.auth(Role.ADMIN))
 
 router.get('/api/matches', [getMatchesController])
+router.get('/api/matches/:id', [getMatchController])
 
 router.post('/api/import/csv', [uploadCsvController])

--- a/packages/backend/tests/functional/match/lucid_match_repository.spec.ts
+++ b/packages/backend/tests/functional/match/lucid_match_repository.spec.ts
@@ -108,6 +108,26 @@ test.group('LucidMatchRepository', (group) => {
     assert.equal(res[0].id.toString(), match1.id.toString())
   })
 
+  test('findById returns a single match', async ({ assert }) => {
+    const match = createMatch('2025-05-05')
+    await MatchModel.create({
+      id: match.id.toString(),
+      date: match.date,
+      heure: match.heure,
+      equipeDomicileId: match.equipeDomicileId.toString(),
+      equipeExterieurId: match.equipeExterieurId.toString(),
+      officiels: match.officiels.map((o) => o.toString()),
+      statut: match.statut,
+      codeRenc: match.codeRenc,
+    })
+
+    const repo = new LucidMatchRepository()
+    const found = await repo.findById(match.id.toString())
+
+    assert.isNotNull(found)
+    assert.equal(found?.id.toString(), match.id.toString())
+  })
+
   test('upsert creates or updates a match', async ({ assert }) => {
     const repo = new LucidMatchRepository()
     const matchId = Identifier.generate().toString()

--- a/packages/backend/tests/unit/match/stubs/stub_match_repository.ts
+++ b/packages/backend/tests/unit/match/stubs/stub_match_repository.ts
@@ -29,6 +29,10 @@ export class StubMatchRepository implements MatchRepository {
     })
   }
 
+  async findById(id: string): Promise<Match | null> {
+    return this.matches.find((m) => m.id.toString() === id) ?? null
+  }
+
   async upsert(match: Match): Promise<void> {
     const index = this.matches.findIndex((m) => m.codeRenc === match.codeRenc)
     if (index >= 0) {

--- a/packages/backend/tests/unit/match/use_case/get_match.spec.ts
+++ b/packages/backend/tests/unit/match/use_case/get_match.spec.ts
@@ -1,0 +1,42 @@
+import { test } from '@japa/runner'
+import Match from '#match/domain/match'
+import Team from '#team/domain/team'
+import { GetMatch } from '#match/service/get_match'
+import { StubMatchRepository } from '#tests/unit/match/stubs/stub_match_repository'
+import { StubTeamRepository } from '#tests/unit/team/stubs/stub_team_repository'
+import { DateTime } from 'luxon'
+
+const equipeHome = '11111111-1111-1111-1111-111111111111'
+const equipeAway = '22222222-2222-2222-2222-222222222222'
+
+function createMatch() {
+  return Match.create({
+    codeRenc: 'CR1',
+    date: DateTime.fromISO('2025-01-01'),
+    heure: '12:00',
+    equipeDomicileId: equipeHome,
+    equipeExterieurId: equipeAway,
+    officiels: [],
+  })
+}
+
+function createTeam(id: string, name: string, code: string) {
+  return Team.create({ id, nom: name, codeFederal: code })
+}
+
+test.group('GetMatch', () => {
+  test('returns match with teams', async ({ assert }) => {
+    const match = createMatch()
+    const teamHome = createTeam(equipeHome, 'Home', 'C1')
+    const teamAway = createTeam(equipeAway, 'Away', 'C2')
+    const matchRepo = new StubMatchRepository([match])
+    const teamRepo = new StubTeamRepository([teamHome, teamAway])
+    const useCase = new GetMatch(matchRepo, teamRepo)
+
+    const res = await useCase.execute(match.id.toString())
+
+    assert.equal(res.match.id.toString(), match.id.toString())
+    assert.equal(res.equipeDomicile.id.toString(), equipeHome)
+    assert.equal(res.equipeExterieur.id.toString(), equipeAway)
+  })
+})


### PR DESCRIPTION
## Summary
- expose `findById` in match repository
- provide in-memory team repository and match detail service
- add route and controller for match detail
- document new endpoint in OpenAPI
- cover with unit and functional tests

## Testing
- `yarn format`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685ce59177308329914a520153985dbf